### PR TITLE
Hotfix: force logout if token is expired

### DIFF
--- a/src/tapis-app/src/Sections/ListSection/ListSection.tsx
+++ b/src/tapis-app/src/Sections/ListSection/ListSection.tsx
@@ -4,6 +4,7 @@ import { useAuthenticator } from 'tapis-redux';
 import { Redirect } from 'react-router-dom';
 import './ListSection.module.scss';
 import { isExpired } from 'tapis-redux/utils';
+import { useDispatch } from 'react-redux';
 
 interface SectionProps {
   children: React.ReactNode[] | React.ReactNode
@@ -35,8 +36,10 @@ export const ListSectionDetail: React.FC<SectionProps> = ({children}) => {
 }
 
 export const ListSection: React.FC<SectionProps> = ({ children }) => {
-  const { token } = useAuthenticator();
+  const dispatch = useDispatch();
+  const { token, logout } = useAuthenticator();
   if (!token || isExpired(token)) {
+    dispatch(logout());
     return <Redirect to="/login" />
   }
   return <div styleName="root">{children}</div>


### PR DESCRIPTION
## Overview: ##

When token expires, force logout. (Expired tokens redirect to login but sidebar state did not reflect being "logged out")

## Related Github Issues: ##

* [TUI-75](https://github.com/tapis-project/tapis-ui/issues/75)

## Summary of Changes: ##

## Testing Steps: ##
1.

## UI Photos:

## Notes: ##
