### PR TITLE
Reset submit status when selecting a different app

### DIFF
--- a/src/tapis-app/src/Sections/Apps/Apps.tsx
+++ b/src/tapis-app/src/Sections/Apps/Apps.tsx
@@ -12,11 +12,16 @@ import {
   ListSectionList,
   ListSectionHeader
 } from 'tapis-app/Sections/ListSection';
+import { useJobs } from 'tapis-redux';
+import { useDispatch } from 'react-redux';
 
 const Apps: React.FC = () => {
+  const { resetSubmit } = useJobs();
+  const dispatch = useDispatch();
   const [initialValues, setInitialValues] = useState<Jobs.ReqSubmitJob>(null);
   const appSelectCallback = useCallback<OnSelectCallback>(
     (app: TapisApp) => {
+      dispatch(resetSubmit());
       const execSystemId = app.jobAttributes && 
         app.jobAttributes.execSystemId ? app.jobAttributes.execSystemId : null;
       setInitialValues({
@@ -24,9 +29,9 @@ const Apps: React.FC = () => {
         appVersion: app.version,
         name: `${app.id}-${app.version}-${new Date().toISOString().slice(0, -5)}`,
         execSystemId
-      })
+      });
     },
-    [ setInitialValues ]
+    [ setInitialValues, dispatch, resetSubmit ]
   )
 
   return (


### PR DESCRIPTION
## Overview: ##

Reset job submission status when selecting a different app

## Related Github Issues: ##

* [TUI-75](https://github.com/tapis-project/tapis-ui/issues/75)

## Summary of Changes: ##

Dispatch resetSubmit when selecting an app in the Apps section

## Testing Steps: ##
1. Log in as cicsvc
2. Launch the sleepseconds.app.demo app
3. Select a different app
4. The job submission status and messages should reset

## UI Photos:

## Notes: ##
