### PR TITLE
task/TUI-104 -- apps list react query

### DIFF
--- a/src/tapis-api/apps/index.ts
+++ b/src/tapis-api/apps/index.ts
@@ -1,0 +1,1 @@
+export { default as list } from './list';

--- a/src/tapis-api/apps/list.ts
+++ b/src/tapis-api/apps/list.ts
@@ -1,6 +1,5 @@
 import { Apps } from '@tapis/tapis-typescript';
-import { apiGenerator } from 'tapis-api/utils';
-import { errorDecoder } from 'tapis-api/utils';
+import { apiGenerator, errorDecoder } from 'tapis-api/utils';
 
 const list = (params: Apps.GetAppsRequest, basePath: string, jwt: string) => {
   const api: Apps.ApplicationsApi = apiGenerator<Apps.ApplicationsApi>(Apps, Apps.ApplicationsApi, basePath, jwt);

--- a/src/tapis-api/apps/list.ts
+++ b/src/tapis-api/apps/list.ts
@@ -1,0 +1,12 @@
+import { Apps } from '@tapis/tapis-typescript';
+import { apiGenerator } from 'tapis-api/utils';
+import { errorDecoder } from 'tapis-api/utils';
+
+const list = (params: Apps.GetAppsRequest, basePath: string, jwt: string) => {
+  const api: Apps.ApplicationsApi = apiGenerator<Apps.ApplicationsApi>(Apps, Apps.ApplicationsApi, basePath, jwt);
+  return errorDecoder<Apps.RespApps>(
+    () => api.getApps(params)
+  );
+}
+
+export default list;

--- a/src/tapis-app/Sections/Apps/Apps.tsx
+++ b/src/tapis-app/Sections/Apps/Apps.tsx
@@ -1,10 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { TapisApp } from '@tapis/tapis-typescript-apps';
-import { useDispatch } from 'react-redux';
-import { useApps, useJobs } from 'tapis-redux';
 import { Jobs } from '@tapis/tapis-typescript';
 import { AppsListing } from 'tapis-ui/components/apps';
-import { OnSelectCallback } from 'tapis-ui/components/apps/AppsListing';
 import JobLauncher from 'tapis-ui/components/jobs/JobLauncher';
 import { SectionMessage, Icon } from 'tapis-ui/_common';
 import { 
@@ -16,13 +13,9 @@ import {
 } from 'tapis-app/Sections/ListSection';
 
 const Apps: React.FC = () => {
-  const { resetSubmit } = useJobs();
-  const dispatch = useDispatch();
   const [initialValues, setInitialValues] = useState<Jobs.ReqSubmitJob | null>(null);
-  const { list } = useApps();
-  const appSelectCallback = useCallback<OnSelectCallback>(
+  const appSelectCallback = useCallback<(app: TapisApp) => any>(
     (app: TapisApp) => {
-      dispatch(resetSubmit());
       const execSystemId = app.jobAttributes && 
         app.jobAttributes.execSystemId ? app.jobAttributes.execSystemId : null;
       setInitialValues({
@@ -32,12 +25,11 @@ const Apps: React.FC = () => {
         execSystemId: execSystemId ?? undefined
       });
     },
-    [ setInitialValues, dispatch, resetSubmit ]
+    [ setInitialValues ]
   )
   const refresh = () => {
     setInitialValues(null);
-    dispatch(list({}));
-}
+  }
 
   return (
     <ListSection>

--- a/src/tapis-app/Sections/Dashboard/Dashboard.tsx
+++ b/src/tapis-app/Sections/Dashboard/Dashboard.tsx
@@ -6,6 +6,7 @@ import { useApps, useJobs  } from 'tapis-redux';
 import { useTapisConfig } from 'tapis-hooks';
 import { LoadingSpinner } from 'tapis-ui/_common';
 import { useList as useSystemsList } from 'tapis-hooks/systems';
+import { useList as useAppsList } from 'tapis-hooks/apps';
 import styles from './Dashboard.module.scss';
 import './Dashboard.scss';
 
@@ -54,8 +55,8 @@ const DashboardCard: React.FC<DashboardCardProps> = ({icon, link, counter, name,
 const Dashboard: React.FC = () => {
   const { accessToken } = useTapisConfig();
   const systems = useSystemsList({});
+  const apps = useAppsList({ select: "jobAttributes,version" });
   const jobs = useJobs();
-  const apps = useApps();
 
   return (
     <div>
@@ -84,8 +85,8 @@ const Dashboard: React.FC = () => {
                 name="Applications"
                 text="View TAPIS applications and launch jobs"
                 link="/apps"
-                counter={`${apps.apps.results.length} apps`}
-                loading={apps.apps.loading}
+                counter={`${apps?.data?.result?.length} apps`}
+                loading={apps?.isLoading}
               />
               <DashboardCard
                 icon="jobs"

--- a/src/tapis-hooks/apps/index.ts
+++ b/src/tapis-hooks/apps/index.ts
@@ -1,0 +1,1 @@
+export { default as useList } from './useList';

--- a/src/tapis-hooks/apps/queryKeys.ts
+++ b/src/tapis-hooks/apps/queryKeys.ts
@@ -1,0 +1,5 @@
+const QueryKeys = {
+  list: 'apps/list'
+}
+
+export default QueryKeys;

--- a/src/tapis-hooks/apps/useList.ts
+++ b/src/tapis-hooks/apps/useList.ts
@@ -1,0 +1,20 @@
+import { useQuery } from 'react-query';
+import { list } from 'tapis-api/apps';
+import { Apps } from '@tapis/tapis-typescript'
+import { useTapisConfig } from 'tapis-hooks';
+
+const useList = (params: Apps.GetAppsRequest) => {
+  const { accessToken, basePath } = useTapisConfig();
+  const result = useQuery<Apps.RespApps, Error>(
+    [params, accessToken],
+    // Default to no token. This will generate a 403 when calling the list function
+    // which is expected behavior for not having a token
+    () => list(params, basePath, accessToken?.access_token || ''),
+    {
+      enabled: !!accessToken
+    }
+  );
+  return result;
+}
+
+export default useList;

--- a/src/tapis-hooks/apps/useList.ts
+++ b/src/tapis-hooks/apps/useList.ts
@@ -2,11 +2,12 @@ import { useQuery } from 'react-query';
 import { list } from 'tapis-api/apps';
 import { Apps } from '@tapis/tapis-typescript'
 import { useTapisConfig } from 'tapis-hooks';
+import QueryKeys from './queryKeys';
 
 const useList = (params: Apps.GetAppsRequest) => {
   const { accessToken, basePath } = useTapisConfig();
   const result = useQuery<Apps.RespApps, Error>(
-    [params, accessToken],
+    [QueryKeys.list, params, accessToken],
     // Default to no token. This will generate a 403 when calling the list function
     // which is expected behavior for not having a token
     () => list(params, basePath, accessToken?.access_token || ''),

--- a/src/tapis-hooks/apps/useList.ts
+++ b/src/tapis-hooks/apps/useList.ts
@@ -10,7 +10,7 @@ const useList = (params: Apps.GetAppsRequest) => {
     [QueryKeys.list, params, accessToken],
     // Default to no token. This will generate a 403 when calling the list function
     // which is expected behavior for not having a token
-    () => list(params, basePath, accessToken?.access_token || ''),
+    () => list(params, basePath, accessToken?.access_token ?? ''),
     {
       enabled: !!accessToken
     }

--- a/src/tapis-ui/components/apps/AppsListing/AppsListing.test.tsx
+++ b/src/tapis-ui/components/apps/AppsListing/AppsListing.test.tsx
@@ -3,13 +3,24 @@ import configureStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
 import renderComponent from 'utils/testing';
 import { AppsListing } from 'tapis-ui/components/apps';
+import { useList } from 'tapis-hooks/apps';
+import { tapisApp } from 'fixtures/apps.fixtures';
 import tapisReduxStore from 'fixtures/tapis-redux.fixture';
 
 const mockStore = configureStore();
 
+jest.mock('tapis-hooks/apps');
+
 describe('Apps', () => {
   it('renders AppsListing component', () => {
     const store = mockStore(tapisReduxStore);
+    (useList as jest.Mock).mockReturnValue({
+      data: {
+        result: [ tapisApp ],
+      },
+      isLoading: false,
+      error: null
+    })
 
     const { getAllByText } = renderComponent(<AppsListing />, store);
     expect(getAllByText(/SleepSeconds/).length).toEqual(1);

--- a/src/tapis-ui/components/apps/AppsListing/AppsListing.tsx
+++ b/src/tapis-ui/components/apps/AppsListing/AppsListing.tsx
@@ -1,13 +1,8 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
-import { useApps } from 'tapis-redux';
-import { AppsListCallback } from 'tapis-redux/apps/list/types';
-import { Config } from 'tapis-redux/types';
+import React, { useState, useCallback } from 'react';
+import { useList } from 'tapis-hooks/apps';
 import { LoadingSpinner, Message, Icon } from 'tapis-ui/_common';
 import { Apps } from '@tapis/tapis-typescript';
 import './AppsListing.scss';
-
-export type OnSelectCallback = (app: Apps.TapisApp) => any;
 
 interface AppsListingItemProps {
   app: Apps.TapisApp,
@@ -29,36 +24,31 @@ const AppsListingItem: React.FC<AppsListingItemProps> = ({ app, onSelect, select
 };
 
 interface AppsListingProps {
-  config?: Config,
-  onList?: AppsListCallback,
-  onSelect?: OnSelectCallback,
+  onSelect?: (app: Apps.TapisApp) => any,
   className?: string
-  select?: string
+  select?: string | undefined
 }
 
 const AppsListing: React.FC<AppsListingProps> = ({
-    config=undefined, onList=undefined, onSelect=undefined, className, select=""
+    onSelect=undefined, className, select=undefined
   }) => {
-  const dispatch = useDispatch();
-  const { list, apps } = useApps(config);
-  useEffect(() => {
-    dispatch(list({ onList, request: { select } }));
-  }, [dispatch, onList, list, select ]);
+
+  const { data, isLoading, error } = useList({ select })
   const [currentApp, setCurrentApp] = useState(String);
   const selectCallback = useCallback((app) => {
     onSelect && onSelect(app);
     setCurrentApp(app.id)
   },[onSelect, setCurrentApp]);
 
-  if (!apps || apps.loading) {
+  if (isLoading) {
     return <LoadingSpinner />
   }
 
-  if (apps.error) {
-    return <Message canDismiss={false} type="error" scope="inline">{apps.error.message}</Message>
+  if (error) {
+    return <Message canDismiss={false} type="error" scope="inline">{(error as any).message}</Message>
   }
 
-  const appList: Array<Apps.TapisApp |null> = apps.results;
+  const appList: Array<Apps.TapisApp> = data?.result || [];
 
   return (
     <div className={className ? className : "apps-list nav flex-column"}>

--- a/src/tapis-ui/components/apps/AppsListing/index.ts
+++ b/src/tapis-ui/components/apps/AppsListing/index.ts
@@ -1,3 +1,2 @@
 import AppsListing from './AppsListing';
-export type { OnSelectCallback } from './AppsListing';
 export default AppsListing;


### PR DESCRIPTION
## Overview: ##

Apps listing uses tapis-hooks and react-query

## Related Github Issues: ##

* [TUI-104](https://github.com/tapis-project/tapis-ui/issues/104)

## Summary of Changes: ##

- Added tapis-api/apps
- Added tapis-hooks/apps/useList
- Converted tapis-ui/AppsListing to use tapis-hooks
- Converted dashboard to use apps useList

## Testing Steps: ##
1. npm test
2. npm start
3. Log in with cicsvc account, browse and see apps

## UI Photos:

## Notes: ##

Jobs Launcher currently does not show the selected app's execution system at this point.
