### PR TITLE
task/TUI-106 - react query jobs submission

### DIFF
--- a/src/tapis-api/authenticator/login.ts
+++ b/src/tapis-api/authenticator/login.ts
@@ -1,7 +1,6 @@
 
 import { Authenticator } from '@tapis/tapis-typescript';
-import { apiGenerator } from 'tapis-api/utils';
-import { errorDecoder } from 'tapis-api/utils';
+import { apiGenerator, errorDecoder } from 'tapis-api/utils';
 
 
 export interface LoginParams {

--- a/src/tapis-api/jobs/index.ts
+++ b/src/tapis-api/jobs/index.ts
@@ -1,2 +1,3 @@
 export { default as list } from './list';
 export { default as details } from './details';
+export { default as submit } from './submit';

--- a/src/tapis-api/jobs/submit.ts
+++ b/src/tapis-api/jobs/submit.ts
@@ -1,14 +1,7 @@
 import { Jobs } from '@tapis/tapis-typescript';
 import { apiGenerator, errorDecoder } from 'tapis-api/utils';
 
-
-export interface SubmitParams {
-  request: Jobs.ReqSubmitJob,
-  basePath: string,
-  jwt: string
-}
-
-const submit = ({ request, basePath, jwt }: SubmitParams): Promise<Jobs.RespSubmitJob>  => {
+const submit = (request: Jobs.ReqSubmitJob, basePath: string, jwt: string): Promise<Jobs.RespSubmitJob>  => {
   const api: Jobs.JobsApi = apiGenerator<Jobs.JobsApi>(Jobs, Jobs.JobsApi, basePath, jwt);
   return errorDecoder<Jobs.RespSubmitJob>(
     () => api.submitJob({ reqSubmitJob: request })

--- a/src/tapis-api/jobs/submit.ts
+++ b/src/tapis-api/jobs/submit.ts
@@ -1,0 +1,18 @@
+import { Jobs } from '@tapis/tapis-typescript';
+import { apiGenerator, errorDecoder } from 'tapis-api/utils';
+
+
+export interface SubmitParams {
+  request: Jobs.ReqSubmitJob,
+  basePath: string,
+  jwt: string
+}
+
+const submit = ({ request, basePath, jwt }: SubmitParams): Promise<Jobs.RespSubmitJob>  => {
+  const api: Jobs.JobsApi = apiGenerator<Jobs.JobsApi>(Jobs, Jobs.JobsApi, basePath, jwt);
+  return errorDecoder<Jobs.RespSubmitJob>(
+    () => api.submitJob({ reqSubmitJob: request })
+  );
+}
+
+export default submit;

--- a/src/tapis-api/utils/errorDecoder.ts
+++ b/src/tapis-api/utils/errorDecoder.ts
@@ -1,3 +1,4 @@
+
 const errorDecoder = async<T>(func: () => Promise<T>) => {
   try {
     // Call the specified function name, and expect that specific return type

--- a/src/tapis-app/Sections/Apps/Apps.tsx
+++ b/src/tapis-app/Sections/Apps/Apps.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from 'react';
 import { TapisApp } from '@tapis/tapis-typescript-apps';
-import { Jobs } from '@tapis/tapis-typescript';
 import { AppsListing } from 'tapis-ui/components/apps';
 import JobLauncher from 'tapis-ui/components/jobs/JobLauncher';
 import { SectionMessage, Icon } from 'tapis-ui/_common';
@@ -13,21 +12,27 @@ import {
 } from 'tapis-app/Sections/ListSection';
 
 const Apps: React.FC = () => {
-  const [initialValues, setInitialValues] = useState<Jobs.ReqSubmitJob | null>(null);
+  const [params, setParams] = useState<{
+    appId: string,
+    appVersion: string,
+    name: string,
+    execSystemId: string
+  } | null>(null);
+
   const appSelectCallback = useCallback<(app: TapisApp) => any>(
     (app: TapisApp) => {
       const execSystemId = app?.jobAttributes?.execSystemId ?? '';
-      setInitialValues({
-        appId: app.id,
-        appVersion: app.version,
+      setParams({
+        appId: app.id ?? '',
+        appVersion: app.version ?? '',
         name: `${app.id}-${app.version}-${new Date().toISOString().slice(0, -5)}`,
         execSystemId
       });
     },
-    [ setInitialValues ]
+    [ setParams ]
   )
   const refresh = () => {
-    setInitialValues(null);
+    setParams(null);
   }
 
   return (
@@ -47,8 +52,13 @@ const Apps: React.FC = () => {
         </ListSectionList>
         <ListSectionDetail>
           <ListSectionHeader type={"sub-header"}>Job Launcher</ListSectionHeader>
-            {initialValues
-              ? <JobLauncher initialValues={initialValues}/>
+            {params
+              ? <JobLauncher
+                  appId={params.appId}
+                  appVersion={params.appVersion}
+                  name={params.name}
+                  execSystemId={params.execSystemId}
+                />
               : <SectionMessage type="info">
                   Select an app from the list.
                 </SectionMessage>

--- a/src/tapis-app/Sections/Apps/Apps.tsx
+++ b/src/tapis-app/Sections/Apps/Apps.tsx
@@ -16,13 +16,12 @@ const Apps: React.FC = () => {
   const [initialValues, setInitialValues] = useState<Jobs.ReqSubmitJob | null>(null);
   const appSelectCallback = useCallback<(app: TapisApp) => any>(
     (app: TapisApp) => {
-      const execSystemId = app.jobAttributes && 
-        app.jobAttributes.execSystemId ? app.jobAttributes.execSystemId : null;
+      const execSystemId = app?.jobAttributes?.execSystemId ?? '';
       setInitialValues({
         appId: app.id,
         appVersion: app.version,
         name: `${app.id}-${app.version}-${new Date().toISOString().slice(0, -5)}`,
-        execSystemId: execSystemId ?? undefined
+        execSystemId
       });
     },
     [ setInitialValues ]

--- a/src/tapis-hooks/jobs/index.ts
+++ b/src/tapis-hooks/jobs/index.ts
@@ -1,2 +1,3 @@
 export { default as useList } from './useList';
 export { default as useDetails } from './useDetails';
+export { default as useSubmit } from './useSubmit';

--- a/src/tapis-hooks/jobs/queryKeys.ts
+++ b/src/tapis-hooks/jobs/queryKeys.ts
@@ -1,6 +1,7 @@
 const QueryKeys = {
   list: 'jobs/list',
-  details: 'jobs/details'
+  details: 'jobs/details',
+  submit: 'jobs/submit'
 }
 
 export default QueryKeys;

--- a/src/tapis-hooks/jobs/useSubmit.ts
+++ b/src/tapis-hooks/jobs/useSubmit.ts
@@ -16,8 +16,7 @@ const useSubmit = () => {
   // The useMutation react-query hook is used to call operations that make server-side changes
   // (Other hooks would be used for data retrieval)
   //
-  // In this case, loginHelper is called to perform the operation, with an onSuccess callback
-  // passed as an option
+  // In this case, submit helper is called to perform the operation
   const { mutate, isLoading, isError, isSuccess, data, error, reset } = useMutation(submit);
 
   // Return hook object with loading states and login function

--- a/src/tapis-hooks/jobs/useSubmit.ts
+++ b/src/tapis-hooks/jobs/useSubmit.ts
@@ -1,0 +1,44 @@
+import { useMutation } from 'react-query';
+import { Jobs } from '@tapis/tapis-typescript';
+import { submit } from 'tapis-api/jobs';
+import { useTapisConfig } from 'tapis-hooks';
+
+type SubmitHookParams = {
+  request: Jobs.ReqSubmitJob,
+  onSuccess?: (data: Jobs.RespSubmitJob) => any,
+  onError?: (error: any) => any
+}
+
+const useSubmit = () => {
+  const { basePath, accessToken } = useTapisConfig();
+  const jwt = accessToken?.access_token || '';
+
+  // The useMutation react-query hook is used to call operations that make server-side changes
+  // (Other hooks would be used for data retrieval)
+  //
+  // In this case, loginHelper is called to perform the operation, with an onSuccess callback
+  // passed as an option
+  const { mutate, isLoading, isError, isSuccess, error } = useMutation(submit);
+
+  // Return hook object with loading states and login function
+  return {
+    isLoading,
+    isError,
+    isSuccess,
+    error,
+    submit: (params: SubmitHookParams) => {
+      const { request, onSuccess, onError } = params;
+
+      // Call mutate to trigger a single post-like API operation
+      return mutate(
+        { request, basePath, jwt },
+        { 
+          onSuccess,
+          onError
+        }
+      )
+    }
+  }
+}
+
+export default useSubmit;

--- a/src/tapis-hooks/jobs/useSubmit.ts
+++ b/src/tapis-hooks/jobs/useSubmit.ts
@@ -18,14 +18,16 @@ const useSubmit = () => {
   //
   // In this case, loginHelper is called to perform the operation, with an onSuccess callback
   // passed as an option
-  const { mutate, isLoading, isError, isSuccess, error } = useMutation(submit);
+  const { mutate, isLoading, isError, isSuccess, data, error, reset } = useMutation(submit);
 
   // Return hook object with loading states and login function
   return {
     isLoading,
     isError,
     isSuccess,
+    data,
     error,
+    reset,
     submit: (params: SubmitHookParams) => {
       const { request, onSuccess, onError } = params;
 

--- a/src/tapis-hooks/jobs/useSubmit.ts
+++ b/src/tapis-hooks/jobs/useSubmit.ts
@@ -1,7 +1,9 @@
+import { useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { Jobs } from '@tapis/tapis-typescript';
 import { submit } from 'tapis-api/jobs';
 import { useTapisConfig } from 'tapis-hooks';
+import QueryKeys from './queryKeys';
 
 type SubmitHookParams = {
   request: Jobs.ReqSubmitJob,
@@ -9,7 +11,7 @@ type SubmitHookParams = {
   onError?: (error: any) => any
 }
 
-const useSubmit = () => {
+const useSubmit = (appId: string, appVersion: string) => {
   const { basePath, accessToken } = useTapisConfig();
   const jwt = accessToken?.access_token || '';
 
@@ -17,7 +19,17 @@ const useSubmit = () => {
   // (Other hooks would be used for data retrieval)
   //
   // In this case, submit helper is called to perform the operation
-  const { mutate, isLoading, isError, isSuccess, data, error, reset } = useMutation(submit);
+  const { mutate, isLoading, isError, isSuccess, data, error, reset } = useMutation(
+    [ QueryKeys.submit, appId, appVersion, basePath, jwt ],
+    (request: Jobs.ReqSubmitJob) => submit(request, basePath, jwt),
+  );
+
+  // We want this hook to automatically reset if a different appId or appVersion
+  // is passed to it. This eliminates the need to reset it inside the TSX component
+  useEffect(
+    () => reset(),
+    [ reset, appId, appVersion ]
+  )
 
   // Return hook object with loading states and login function
   return {
@@ -29,10 +41,9 @@ const useSubmit = () => {
     reset,
     submit: (params: SubmitHookParams) => {
       const { request, onSuccess, onError } = params;
-
       // Call mutate to trigger a single post-like API operation
       return mutate(
-        { request, basePath, jwt },
+        request,
         { 
           onSuccess,
           onError

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.test.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.test.tsx
@@ -19,7 +19,10 @@ describe('JobLauncher', () => {
       name: `Mock Job`,
       execSystemId: 'tapisv3-exec'
     }
-    const { getAllByTestId } = renderComponent(<JobLauncher initialValues={initialValues} />, store);
+    const { getAllByTestId } = renderComponent(
+      <JobLauncher appId="SleepSeconds" appVersion="0.1" name="test-job" execSystemId="exec-system "/>,
+      store
+    );
     const input: any = getAllByTestId('appId');
     expect(input[0].value).toEqual('SleepSeconds');
   });

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useList } from 'tapis-hooks/systems';
 import { useSubmit } from 'tapis-hooks/jobs';
 import { Formik, Form,} from 'formik';
@@ -20,12 +20,15 @@ import './JobLauncher.scss';
 export type OnSubmitCallback = (job: Jobs.Job) => any;
 
 interface JobLauncherProps {
-  initialValues?: Jobs.ReqSubmitJob,
+  appId: string,
+  appVersion: string,
+  name: string,
+  execSystemId: string
 }
 
-const JobLauncher: React.FC<JobLauncherProps> = ({ initialValues={} }) => {
+const JobLauncher: React.FC<JobLauncherProps> = ({ appId, appVersion, name, execSystemId }) => {
   const systemsListHook = useList({});
-  const { submit, isLoading, error, data, reset } = useSubmit();
+  const { submit, isLoading, error, data } = useSubmit(appId, appVersion);
 
   const systems: Array<TapisSystem> = systemsListHook.data?.result ?? [];
 
@@ -40,12 +43,7 @@ const JobLauncher: React.FC<JobLauncherProps> = ({ initialValues={} }) => {
     setSubmitting(false);
   }
 
-  useEffect(
-    () => {
-      reset();
-    },
-    [ reset, initialValues ]
-  )
+  const initialValues = Jobs.ReqSubmitJobFromJSON({ appId, appVersion, name, execSystemId });
 
   const jobFields: Array<FieldWrapperProps> = [
     {
@@ -101,7 +99,7 @@ const JobLauncher: React.FC<JobLauncherProps> = ({ initialValues={} }) => {
   return (
     <div>
       <Formik
-        initialValues={initialValues ?? {}}
+        initialValues={initialValues}
         enableReinitialize={true}
         validationSchema={validationSchema}
         onSubmit={formSubmit}


### PR DESCRIPTION
## Overview: ##

Jobs Submission uses react-query

## Related Github Issues: ##

* [TUI-106](https://github.com/tapis-project/tapis-ui/issues/106)

## Summary of Changes: ##

- tapis-api/jobs/submit
- tapis-hooks/jobs/useSubmit
- JobsLauncher uses react-query hooks

## Testing Steps: ##
1. npm start
2. Launch a job from an application
3. Switch to a different application - job submission state should reset
4. Change the exec system to something that's not the default. Upon submission you should see an error message
5. Switch to a different application - job submission state and error should reset

## UI Photos:

## Notes: ##
