### PR TITLE
Type generics for react-hook-form

### DIFF
--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -11,8 +11,8 @@ import { Collapse } from 'tapis-ui/_common';
 import styles from './FieldArray.module.scss';
 
 export type FieldArrayComponent<T> = React.FC<{
-  refName: string;
   item: FieldArrayWithId<T, ArrayPath<T>, 'id'>;
+  index: number;
 }>;
 
 type FieldArrayProps<T> = {
@@ -50,7 +50,7 @@ export function FieldArray<T>({
           <div className={styles.item}>
             {render({
               item,
-              refName: `${refName}.${index}`,
+              index
             })}
             {!(index in required) && (
               <Button

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -1,24 +1,27 @@
 import React from 'react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import {
+  useFieldArray,
+  useFormContext,
+  FieldArrayPath,
+  FieldArrayWithId,
+  ArrayPath,
+} from 'react-hook-form';
 import { Button } from 'reactstrap';
 import { Collapse } from 'tapis-ui/_common';
 import styles from './FieldArray.module.scss';
 
-export type FieldArrayComponent = React.FC<{
+export type FieldArrayComponent<T> = React.FC<{
   refName: string;
-  item: {
-    id: string;
-    [name: string]: any;
-  };
+  item: FieldArrayWithId<T, ArrayPath<T>, 'id'>;
 }>;
 
-type FieldArrayProps = {
+type FieldArrayProps<T> = {
   // react-hook-form data ref
-  refName: string;
+  refName: FieldArrayPath<T>;
   // Title for collapse panel
   title: string;
   // Custom component to render field
-  render: FieldArrayComponent;
+  render: FieldArrayComponent<T>;
   // Data template when appending new fields
   appendData: any;
   // react-hook-form control hook
@@ -26,15 +29,15 @@ type FieldArrayProps = {
   required?: Array<number>;
 };
 
-export const FieldArray: React.FC<FieldArrayProps> = ({
+export function FieldArray<T>({
   refName,
   title,
   render,
   appendData,
   addButtonText,
   required = [],
-}) => {
-  const { control } = useFormContext();
+}: FieldArrayProps<T>) {
+  const { control } = useFormContext<T>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: refName,
@@ -66,4 +69,4 @@ export const FieldArray: React.FC<FieldArrayProps> = ({
       </Collapse>
     </div>
   );
-};
+}

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -8,14 +8,16 @@ import { mapInnerRef } from 'tapis-ui/utils/forms';
 import { Jobs } from '@tapis/tapis-typescript';
 
 const FileInputField: FieldArrayComponent<Jobs.ReqSubmitJob> = ({
-  refName,
+  index,
   item,
 }) => {
   const {
     register,
     formState: { errors },
-  } = useFormContext();
+  } = useFormContext<Jobs.ReqSubmitJob>();
   const { sourceUrl, targetPath, inPlace, id } = item;
+
+  const errorObj = errors.fileInputs;
 
   return (
     <div key={id}>
@@ -23,13 +25,13 @@ const FileInputField: FieldArrayComponent<Jobs.ReqSubmitJob> = ({
         label="Source URL"
         required={true}
         description="Input TAPIS file as a pathname, TAPIS URI or web URL"
-        error={errors['sourceUrl']}
+        error={errorObj && errorObj[index]?.sourceUrl}
       >
         <Input
           bsSize="sm"
           defaultValue={sourceUrl}
           {...mapInnerRef(
-            register(`${refName}.sourceUrl`, {
+            register(`fileInputs.${index}.sourceUrl`, {
               required: 'Source URL is required',
             })
           )}
@@ -39,13 +41,13 @@ const FileInputField: FieldArrayComponent<Jobs.ReqSubmitJob> = ({
         label="Target Path"
         required={true}
         description="File mount path inside of running container"
-        error={errors['targetPath']}
+        error={errorObj && errorObj[index]?.targetPath}
       >
         <Input
           bsSize="sm"
           defaultValue={targetPath}
           {...mapInnerRef(
-            register(`${refName}.targetPath`, {
+            register(`fileInputs.${index}.targetPath`, {
               required: 'Target Path is required',
             })
           )}
@@ -57,7 +59,7 @@ const FileInputField: FieldArrayComponent<Jobs.ReqSubmitJob> = ({
             type="checkbox"
             bsSize="sm"
             defaultChecked={inPlace}
-            {...mapInnerRef(register(`${refName}.inPlace`))}
+            {...mapInnerRef(register(`fileInputs.${index}.inPlace`))}
           />{' '}
           In Place
         </Label>
@@ -76,6 +78,7 @@ type FileInputsProps = {
 
 const FileInputs: React.FC<FileInputsProps> = ({ inputs }) => {
   const refName: FieldArrayPath<Jobs.ReqSubmitJob> = 'fileInputs';
+
   const required = Array.from(
     inputs.filter((fileInput) => fileInput?.meta?.required).keys()
   );

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, FieldArrayPath } from 'react-hook-form';
 import { FileInput } from '@tapis/tapis-typescript-apps';
 import { FieldArray, FieldArrayComponent } from './FieldArray';
 import FieldWrapper from 'tapis-ui/_common/FieldWrapper';
 import { Input, Label, FormText, FormGroup } from 'reactstrap';
 import { mapInnerRef } from 'tapis-ui/utils/forms';
+import { Jobs } from '@tapis/tapis-typescript';
 
-const FileInputField: FieldArrayComponent = ({ refName, item }) => {
+const FileInputField: FieldArrayComponent<Jobs.ReqSubmitJob> = ({
+  refName,
+  item,
+}) => {
   const {
     register,
     formState: { errors },
@@ -71,7 +75,7 @@ type FileInputsProps = {
 };
 
 const FileInputs: React.FC<FileInputsProps> = ({ inputs }) => {
-  const refName = 'fileInputs';
+  const refName: FieldArrayPath<Jobs.ReqSubmitJob> = 'fileInputs';
   const required = Array.from(
     inputs.filter((fileInput) => fileInput?.meta?.required).keys()
   );
@@ -87,16 +91,14 @@ const FileInputs: React.FC<FileInputsProps> = ({ inputs }) => {
     },
   };
 
-  return (
-    <FieldArray
-      title="File Inputs"
-      appendData={appendData}
-      addButtonText="Add File Input"
-      refName={refName}
-      render={FileInputField}
-      required={required}
-    />
-  );
+  return FieldArray<Jobs.ReqSubmitJob>({
+    title: 'File Inputs',
+    addButtonText: 'Add File Input',
+    appendData,
+    refName,
+    render: FileInputField,
+    required,
+  });
 };
 
 export default FileInputs;


### PR DESCRIPTION
## Overview:

Add type specification to useForm and propagate downward to FieldArray component

- By adding the desired form type, this adds validation to name paths so that you can only use name paths that exist within the form type. (For example, this detected that the jobAttributes.fileInputs pathname did not actually exist in the ReqJobsSubmit type)
- This does not solve enforcing an item type. the type of item resolves to `never`, and each destructured field of the item is now `never`

## Related Github Issues:

- [TUI-1234](https://github.com/tapis-project/tapis-ui/issues/1234)

## Summary of Changes:

## Testing Steps:

1.

## UI Photos:

## Notes:
