### PR TITLE
task/TUI-162 - Move remove button display concern to rendered component

### DIFF
--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.module.scss
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.module.scss
@@ -9,7 +9,3 @@
   padding: 0.5em 0.5em 0.5em 0.5em;
   margin-bottom: 1em;
 }
-
-.remove {
-  margin-top: 0.75em;
-}

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -34,7 +34,7 @@ export function FieldArray<T>({
   render,
   appendData,
   addButtonText,
-  required,
+  required = [],
 }: FieldArrayProps<T>) {
   const { control } = useFormContext<Record<typeof name, T[]>>();
   const { fields, append, remove } = useFieldArray({
@@ -50,10 +50,7 @@ export function FieldArray<T>({
             {render({
               item,
               index,
-              remove:
-                !required || !(index in required)
-                  ? () => remove(index)
-                  : undefined,
+              remove: !(index in required) ? () => remove(index) : undefined,
             })}
           </div>
         ))}

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -11,6 +11,7 @@ type FieldItem<T> = {
 export type FieldArrayComponent<T> = React.FC<{
   index: number;
   item: FieldItem<T>;
+  remove: () => any;
 }>;
 
 type FieldArrayProps<T> = {
@@ -24,7 +25,6 @@ type FieldArrayProps<T> = {
   appendData: T;
   // react-hook-form control hook
   addButtonText?: string;
-  required?: Array<number>;
 };
 
 export function FieldArray<T>({
@@ -33,7 +33,6 @@ export function FieldArray<T>({
   render,
   appendData,
   addButtonText,
-  required = [],
 }: FieldArrayProps<T>) {
   const { control } = useFormContext<Record<typeof name, T[]>>();
   const { fields, append, remove } = useFieldArray({
@@ -49,16 +48,8 @@ export function FieldArray<T>({
             {render({
               item,
               index,
+              remove: () => remove(index),
             })}
-            {!(index in required) && (
-              <Button
-                onClick={() => remove(index)}
-                size="sm"
-                className={styles.remove}
-              >
-                Remove
-              </Button>
-            )}
           </div>
         ))}
         <Button onClick={() => append(appendData)} size="sm">

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -11,7 +11,7 @@ type FieldItem<T> = {
 export type FieldArrayComponent<T> = React.FC<{
   index: number;
   item: FieldItem<T>;
-  remove: () => any;
+  remove?: () => any;
 }>;
 
 type FieldArrayProps<T> = {
@@ -25,6 +25,7 @@ type FieldArrayProps<T> = {
   appendData: T;
   // react-hook-form control hook
   addButtonText?: string;
+  required?: Array<number>;
 };
 
 export function FieldArray<T>({
@@ -33,6 +34,7 @@ export function FieldArray<T>({
   render,
   appendData,
   addButtonText,
+  required,
 }: FieldArrayProps<T>) {
   const { control } = useFormContext<Record<typeof name, T[]>>();
   const { fields, append, remove } = useFieldArray({
@@ -48,7 +50,10 @@ export function FieldArray<T>({
             {render({
               item,
               index,
-              remove: () => remove(index),
+              remove:
+                !required || !(index in required)
+                  ? () => remove(index)
+                  : undefined,
             })}
           </div>
         ))}

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.module.scss
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.module.scss
@@ -1,0 +1,3 @@
+.remove {
+  margin-top: 0.75em;
+}

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -70,7 +70,7 @@ const FileInputField: FieldArrayComponent<FileInput> = ({
           system's local file system
         </FormText>
       </FormGroup>
-      {!meta?.required && (
+      {remove && !meta?.required && (
         <Button onClick={() => remove()} size="sm" className={styles.remove}>
           Remove
         </Button>
@@ -79,8 +79,16 @@ const FileInputField: FieldArrayComponent<FileInput> = ({
   );
 };
 
-const FileInputs: React.FC = () => {
+type FileInputsProps = {
+  appInputs: Array<FileInput>;
+};
+
+const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
   const name: FieldArrayPath<ReqSubmitJob> = 'fileInputs';
+
+  const required = Array.from(
+    appInputs.filter((fileInput) => fileInput?.meta?.required).keys()
+  );
 
   const appendData: FileInput = {
     sourceUrl: '',
@@ -98,6 +106,7 @@ const FileInputs: React.FC = () => {
     addButtonText: 'Add File Input',
     name,
     render: FileInputField,
+    required,
     appendData,
   });
 };

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -6,8 +6,14 @@ import FieldWrapper from 'tapis-ui/_common/FieldWrapper';
 import { Input, Label, FormText, FormGroup } from 'reactstrap';
 import { mapInnerRef } from 'tapis-ui/utils/forms';
 import { ReqSubmitJob } from '@tapis/tapis-typescript-jobs';
+import { Button } from 'reactstrap';
+import styles from './FileInputs.module.scss';
 
-const FileInputField: FieldArrayComponent<FileInput> = ({ item, index }) => {
+const FileInputField: FieldArrayComponent<FileInput> = ({
+  item,
+  index,
+  remove,
+}) => {
   const {
     register,
     formState: { errors },
@@ -64,20 +70,15 @@ const FileInputField: FieldArrayComponent<FileInput> = ({ item, index }) => {
           system's local file system
         </FormText>
       </FormGroup>
+      <Button onClick={() => remove()} size="sm" className={styles.remove}>
+        Remove
+      </Button>
     </div>
   );
 };
 
-type FileInputsProps = {
-  inputs: Array<FileInput>;
-};
-
-const FileInputs: React.FC<FileInputsProps> = ({ inputs }) => {
+const FileInputs: React.FC = () => {
   const name: FieldArrayPath<ReqSubmitJob> = 'fileInputs';
-
-  const required = Array.from(
-    inputs.filter((fileInput) => fileInput?.meta?.required).keys()
-  );
 
   const appendData: FileInput = {
     sourceUrl: '',
@@ -95,7 +96,6 @@ const FileInputs: React.FC<FileInputsProps> = ({ inputs }) => {
     addButtonText: 'Add File Input',
     name,
     render: FileInputField,
-    required,
     appendData,
   });
 };

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -18,7 +18,7 @@ const FileInputField: FieldArrayComponent<FileInput> = ({
     register,
     formState: { errors },
   } = useFormContext<ReqSubmitJob>();
-  const { sourceUrl, targetPath, inPlace, id } = item;
+  const { sourceUrl, targetPath, inPlace, meta, id } = item;
   const itemError = errors?.fileInputs && errors.fileInputs[index];
 
   return (
@@ -70,9 +70,11 @@ const FileInputField: FieldArrayComponent<FileInput> = ({
           system's local file system
         </FormText>
       </FormGroup>
-      <Button onClick={() => remove()} size="sm" className={styles.remove}>
-        Remove
-      </Button>
+      {!meta?.required && (
+        <Button onClick={() => remove()} size="sm" className={styles.remove}>
+          Remove
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.tsx
@@ -144,7 +144,9 @@ const JobLauncher: React.FC<JobLauncherProps> = ({
             </Input>
           </FieldWrapper>
 
-          <FileInputs />
+          <FileInputs
+            appInputs={app?.result?.jobAttributes?.fileInputs ?? []}
+          />
 
           {/* Submit button */}
           <SubmitWrapper

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.tsx
@@ -144,7 +144,7 @@ const JobLauncher: React.FC<JobLauncherProps> = ({
             </Input>
           </FieldWrapper>
 
-          <FileInputs inputs={app?.result?.jobAttributes?.fileInputs ?? []} />
+          <FileInputs />
 
           {/* Submit button */}
           <SubmitWrapper


### PR DESCRIPTION
## Overview:

FieldArray now passes a remove callback to the rendered component

## Related Github Issues:

- [TUI-162](https://github.com/tapis-project/tapis-ui/issues/162)

## Summary of Changes:

- FieldArray passes remove callback to rendered component
- FileInputField now selectively renders a remove button based on meta.required and if remove callback is present
- FileInputs inputs property renamed to appInputs to better reflect where the source FileInput definitions are coming from

## Testing Steps:

1. Add a file input to a job launch
2. make sure required ones are not removable
3. make sure added fileinputs are removable

## UI Photos:

## Notes:

