### PR TITLE
Add optional collapsable UI to FileInputs FieldArray

### DIFF
--- a/src/tapis-ui/_common/Collapse/Collapse.tsx
+++ b/src/tapis-ui/_common/Collapse/Collapse.tsx
@@ -8,6 +8,7 @@ type CollapseProperties = React.PropsWithChildren<{
   title: string;
   note?: string;
   open?: boolean;
+  isCollapsable?: boolean;
   className?: string;
 }>;
 
@@ -17,29 +18,41 @@ const Collapse: React.FC<CollapseProperties> = ({
   open,
   className,
   children,
+  isCollapsable,
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(open ?? false);
   const toggle = useCallback(() => {
     setIsOpen(!isOpen);
   }, [isOpen, setIsOpen]);
 
+  isCollapsable = isCollapsable ? isCollapsable != undefined : false;
+
+  // Only render collapsable UI if isCollapsable defined and true
   return (
     <div className={className}>
       <div className={styles.header}>
         <div className={styles.title}>{title}</div>
         <div className={styles.controls}>
           <div>{note ?? ''}</div>
-          <Button
-            color="link"
-            className={styles.expand}
-            size="sm"
-            onClick={toggle}
-          >
-            <Icon name={isOpen ? 'collapse' : 'expand'} />
-          </Button>
+          {!isCollapsable ? (
+            ''
+          ) : (
+            <Button
+              color="link"
+              className={styles.expand}
+              size="sm"
+              onClick={toggle}
+            >
+              <Icon name={isOpen ? 'collapse' : 'expand'} />
+            </Button>
+          )}
         </div>
       </div>
-      <BootstrapCollapse isOpen={isOpen}>{children}</BootstrapCollapse>
+      {!isCollapsable ? (
+        <div>{ children }</div>
+      ) : (
+        <BootstrapCollapse isOpen={isOpen}>{children}</BootstrapCollapse>
+      )}
     </div>
   );
 };

--- a/src/tapis-ui/_common/Collapse/Collapse.tsx
+++ b/src/tapis-ui/_common/Collapse/Collapse.tsx
@@ -18,14 +18,12 @@ const Collapse: React.FC<CollapseProperties> = ({
   open,
   className,
   children,
-  isCollapsable,
+  isCollapsable = true,
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(open ?? false);
   const toggle = useCallback(() => {
     setIsOpen(!isOpen);
   }, [isOpen, setIsOpen]);
-
-  isCollapsable = isCollapsable ? isCollapsable !== undefined : false;
 
   // Only render collapsable UI if isCollapsable defined and true
   return (

--- a/src/tapis-ui/_common/Collapse/Collapse.tsx
+++ b/src/tapis-ui/_common/Collapse/Collapse.tsx
@@ -32,9 +32,7 @@ const Collapse: React.FC<CollapseProperties> = ({
         <div className={styles.title}>{title}</div>
         <div className={styles.controls}>
           <div>{note ?? ''}</div>
-          {!isCollapsable ? (
-            ''
-          ) : (
+          {isCollapsable && (
             <Button
               color="link"
               className={styles.expand}
@@ -46,11 +44,9 @@ const Collapse: React.FC<CollapseProperties> = ({
           )}
         </div>
       </div>
-      {!isCollapsable ? (
-        <div>{children}</div>
-      ) : (
-        <BootstrapCollapse isOpen={isOpen}>{children}</BootstrapCollapse>
-      )}
+      <BootstrapCollapse isOpen={isOpen || !isCollapsable}>
+        {children}
+      </BootstrapCollapse>
     </div>
   );
 };

--- a/src/tapis-ui/_common/Collapse/Collapse.tsx
+++ b/src/tapis-ui/_common/Collapse/Collapse.tsx
@@ -49,7 +49,7 @@ const Collapse: React.FC<CollapseProperties> = ({
         </div>
       </div>
       {!isCollapsable ? (
-        <div>{ children }</div>
+        <div>{children}</div>
       ) : (
         <BootstrapCollapse isOpen={isOpen}>{children}</BootstrapCollapse>
       )}

--- a/src/tapis-ui/_common/Collapse/Collapse.tsx
+++ b/src/tapis-ui/_common/Collapse/Collapse.tsx
@@ -25,7 +25,7 @@ const Collapse: React.FC<CollapseProperties> = ({
     setIsOpen(!isOpen);
   }, [isOpen, setIsOpen]);
 
-  isCollapsable = isCollapsable ? isCollapsable != undefined : false;
+  isCollapsable = isCollapsable ? isCollapsable !== undefined : false;
 
   // Only render collapsable UI if isCollapsable defined and true
   return (

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -50,7 +50,7 @@ export function FieldArray<T>({
         open={required.length > 0}
         title={title}
         note={`${fields.length} items`}
-        isCollapsable={isCollapsable && required.length > 0}
+        isCollapsable={isCollapsable}
       >
         {fields.map((item, index) => (
           <div className={styles.item}>

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -26,7 +26,7 @@ type FieldArrayProps<T> = {
   // react-hook-form control hook
   addButtonText?: string;
   required?: Array<number>;
-  isCollapsable?: boolean
+  isCollapsable?: boolean;
 };
 
 export function FieldArray<T>({
@@ -46,9 +46,12 @@ export function FieldArray<T>({
 
   return (
     <div className={styles.array}>
-      {
-        required.length > 0 && isCollapsable ?
-        <Collapse open={(required.length > 0)} title={title} note={`${fields.length} items`}>
+      {required.length > 0 && isCollapsable ? (
+        <Collapse
+          open={required.length > 0}
+          title={title}
+          note={`${fields.length} items`}
+        >
           {fields.map((item, index) => (
             <div className={styles.item}>
               {render({
@@ -61,7 +64,8 @@ export function FieldArray<T>({
           <Button onClick={() => append(appendData)} size="sm">
             + {addButtonText ?? ''}
           </Button>
-        </Collapse> :
+        </Collapse>
+      ) : (
         <div>
           <h2>{title}</h2>
           {fields.map((item, index) => (
@@ -77,8 +81,7 @@ export function FieldArray<T>({
             + {addButtonText ?? ''}
           </Button>
         </div>
-        
-      }
+      )}
     </div>
   );
 }

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -26,6 +26,7 @@ type FieldArrayProps<T> = {
   // react-hook-form control hook
   addButtonText?: string;
   required?: Array<number>;
+  isCollapsable?: boolean
 };
 
 export function FieldArray<T>({
@@ -35,6 +36,7 @@ export function FieldArray<T>({
   appendData,
   addButtonText,
   required = [],
+  isCollapsable,
 }: FieldArrayProps<T>) {
   const { control } = useFormContext<Record<typeof name, T[]>>();
   const { fields, append, remove } = useFieldArray({
@@ -44,20 +46,39 @@ export function FieldArray<T>({
 
   return (
     <div className={styles.array}>
-      <Collapse title={title} note={`${fields.length} items`}>
-        {fields.map((item, index) => (
-          <div className={styles.item}>
-            {render({
-              item,
-              index,
-              remove: !(index in required) ? () => remove(index) : undefined,
-            })}
-          </div>
-        ))}
-        <Button onClick={() => append(appendData)} size="sm">
-          + {addButtonText ?? ''}
-        </Button>
-      </Collapse>
+      {
+        required.length > 0 && isCollapsable ?
+        <Collapse open={(required.length > 0)} title={title} note={`${fields.length} items`}>
+          {fields.map((item, index) => (
+            <div className={styles.item}>
+              {render({
+                item,
+                index,
+                remove: !(index in required) ? () => remove(index) : undefined,
+              })}
+            </div>
+          ))}
+          <Button onClick={() => append(appendData)} size="sm">
+            + {addButtonText ?? ''}
+          </Button>
+        </Collapse> :
+        <div>
+          <h2>{title}</h2>
+          {fields.map((item, index) => (
+            <div className={styles.item}>
+              {render({
+                item,
+                index,
+                remove: !(index in required) ? () => remove(index) : undefined,
+              })}
+            </div>
+          ))}
+          <Button onClick={() => append(appendData)} size="sm">
+            + {addButtonText ?? ''}
+          </Button>
+        </div>
+        
+      }
     </div>
   );
 }

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -46,42 +46,25 @@ export function FieldArray<T>({
 
   return (
     <div className={styles.array}>
-      {required.length > 0 && isCollapsable ? (
-        <Collapse
-          open={required.length > 0}
-          title={title}
-          note={`${fields.length} items`}
-        >
-          {fields.map((item, index) => (
-            <div className={styles.item}>
-              {render({
-                item,
-                index,
-                remove: !(index in required) ? () => remove(index) : undefined,
-              })}
-            </div>
-          ))}
-          <Button onClick={() => append(appendData)} size="sm">
-            + {addButtonText ?? ''}
-          </Button>
-        </Collapse>
-      ) : (
-        <div>
-          <h2>{title}</h2>
-          {fields.map((item, index) => (
-            <div className={styles.item}>
-              {render({
-                item,
-                index,
-                remove: !(index in required) ? () => remove(index) : undefined,
-              })}
-            </div>
-          ))}
-          <Button onClick={() => append(appendData)} size="sm">
-            + {addButtonText ?? ''}
-          </Button>
-        </div>
-      )}
+      <Collapse
+        open={required.length > 0}
+        title={title}
+        note={`${fields.length} items`}
+        isCollapsable={isCollapsable && required.length > 0}
+      >
+        {fields.map((item, index) => (
+          <div className={styles.item}>
+            {render({
+              item,
+              index,
+              remove: !(index in required) ? () => remove(index) : undefined,
+            })}
+          </div>
+        ))}
+        <Button onClick={() => append(appendData)} size="sm">
+          + {addButtonText ?? ''}
+        </Button>
+      </Collapse>
     </div>
   );
 }

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -109,7 +109,7 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
     name,
     render: FileInputField,
     required,
-    appendData
+    appendData,
   });
 };
 

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useFormContext, FieldArrayPath } from 'react-hook-form';
-import { FileInput } from '@tapis/tapis-typescript-apps';
+import { FileInput as FileInput } from '@tapis/tapis-typescript-apps';
 import { FieldArray, FieldArrayComponent } from './FieldArray';
 import FieldWrapper from 'tapis-ui/_common/FieldWrapper';
 import { Input, Label, FormText, FormGroup } from 'reactstrap';
@@ -89,7 +89,7 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
   const required = Array.from(
     appInputs.filter((fileInput) => fileInput?.meta?.required).keys()
   );
-
+  
   const appendData: FileInput = {
     sourceUrl: '',
     targetPath: '',
@@ -108,6 +108,7 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
     render: FileInputField,
     required,
     appendData,
+    isCollapsable: true
   });
 };
 

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -89,7 +89,7 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
   const required = Array.from(
     appInputs.filter((fileInput) => fileInput?.meta?.required).keys()
   );
-  
+
   const appendData: FileInput = {
     sourceUrl: '',
     targetPath: '',
@@ -108,7 +108,7 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
     render: FileInputField,
     required,
     appendData,
-    isCollapsable: true
+    isCollapsable: true,
   });
 };
 

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useFormContext, FieldArrayPath } from 'react-hook-form';
-import { FileInput as FileInput } from '@tapis/tapis-typescript-apps';
+import { FileInput } from '@tapis/tapis-typescript-apps';
 import { FieldArray, FieldArrayComponent } from './FieldArray';
 import FieldWrapper from 'tapis-ui/_common/FieldWrapper';
 import { Input, Label, FormText, FormGroup } from 'reactstrap';

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -107,8 +107,7 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
     name,
     render: FileInputField,
     required,
-    appendData,
-    isCollapsable: required.length > 0,
+    appendData
   });
 };
 

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -108,7 +108,7 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
     render: FileInputField,
     required,
     appendData,
-    isCollapsable: true,
+    isCollapsable: required.length > 0,
   });
 };
 


### PR DESCRIPTION
## Overview:
Make FileInputs FieldArray optionally collapsable.

## Related Github Issues:
- [TUI-164](https://github.com/tapis-project/tapis-ui/issues/164)

## Summary of Changes:
- Added isCollapsable flag FieldArray
- Default isCollapsable to true in FileInputs
- Render FieldArray with Collapse only if isCollapsable prop on FieldArray is true and there are required FileInputs
- Default open to true if there are required FileInputs

## Testing Steps:
1. Navigate to Apps
2. Click the 'bsf2 v1' app link. Expect Collapse to be rendered and open
3. Click the SleepSeconds.app.demo v0.0.1 link. Expect Collapse not to be rendered

## UI Photos:
<img width="892" alt="Screen Shot 2021-09-18 at 2 34 50 PM" src="https://user-images.githubusercontent.com/59402772/133906925-e53054ca-0304-4c41-afa3-1d833986b2b5.png">
<img width="893" alt="Screen Shot 2021-09-18 at 2 48 37 PM" src="https://user-images.githubusercontent.com/59402772/133906932-a868e070-2e9c-45e9-8675-0e58c2960fd8.png">

