### PR TITLE
ArrayField type scheme with more idiomatic generics

### DIFF
--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -10,7 +10,7 @@ type FieldItem<T> = {
 
 export type FieldArrayComponent<T> = React.FC<{
   index: number;
-  item: T & { id: string};
+  item: FieldItem<T>;
 }>;
 
 type FieldArrayProps<T> = {

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -1,44 +1,55 @@
 import React from 'react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import {
+  useFieldArray,
+  useFormContext,
+  ArrayPath,
+  FieldArrayWithId,
+  FieldArray as TFieldArray,
+} from 'react-hook-form';
 import { Button } from 'reactstrap';
 import { Collapse } from 'tapis-ui/_common';
 import styles from './FieldArray.module.scss';
 
-type FieldItem<T> = {
-  id: string;
-} & T;
-
-export type FieldArrayComponent<T> = React.FC<{
+export type FieldArrayComponent<
+  TFieldValues,
+  TArrayPath extends ArrayPath<TFieldValues>
+> = React.FC<{
   index: number;
-  item: FieldItem<T>;
+  item: FieldArrayWithId<Required<TFieldValues>, TArrayPath>;
 }>;
 
-type FieldArrayProps<T> = {
+type FieldArrayProps<
+  TFieldValues,
+  TArrayPath extends ArrayPath<TFieldValues>
+> = {
   // react-hook-form data ref
-  name: string;
+  name: TArrayPath;
   // Title for collapse panel
   title: string;
   // Custom component to render field
-  render: FieldArrayComponent<T>;
+  render: FieldArrayComponent<TFieldValues, TArrayPath>;
   // Data template when appending new fields
-  appendData: T;
+  appendData: TFieldArray<TFieldValues, TArrayPath>;
   // react-hook-form control hook
   addButtonText?: string;
   required?: Array<number>;
 };
 
-export function FieldArray<T>({
+export function FieldArray<
+  TFieldValues,
+  TArrayPath extends ArrayPath<TFieldValues>
+>({
   name,
   title,
   render,
   appendData,
   addButtonText,
   required = [],
-}: FieldArrayProps<T>) {
-  const { control } = useFormContext<Record<typeof name, T[]>>();
+}: FieldArrayProps<Required<TFieldValues>, TArrayPath>) {
+  const { control } = useFormContext<TFieldValues>();
   const { fields, append, remove } = useFieldArray({
     control,
-    name: name as any,
+    name,
   });
 
   return (

--- a/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldArray.tsx
@@ -10,7 +10,7 @@ type FieldItem<T> = {
 
 export type FieldArrayComponent<T> = React.FC<{
   index: number;
-  item: FieldItem<T>;
+  item: T & { id: string};
 }>;
 
 type FieldArrayProps<T> = {
@@ -35,10 +35,10 @@ export function FieldArray<T>({
   addButtonText,
   required = [],
 }: FieldArrayProps<T>) {
-  const { control } = useFormContext();
+  const { control } = useFormContext<Record<typeof name, T[]>>();
   const { fields, append, remove } = useFieldArray({
     control,
-    name,
+    name: name as any,
   });
 
   return (
@@ -47,7 +47,7 @@ export function FieldArray<T>({
         {fields.map((item, index) => (
           <div className={styles.item}>
             {render({
-              item: item as FieldItem<T>,
+              item,
               index,
             })}
             {!(index in required) && (

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -96,11 +96,13 @@ const FileInputs: React.FC<{ appInputs: FileInput[] }> = ({ appInputs }) => {
     },
   };
 
+  const name = 'fileInputs';
+
   return (
-    <FieldArray<ReqSubmitJob, 'fileInputs'>
+    <FieldArray<ReqSubmitJob, typeof name>
       title="File Inputs"
       addButtonText="Add File Input"
-      name="fileInputs"
+      name={name}
       render={FileInputField}
       required={required}
       appendData={appendData}

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -11,7 +11,7 @@ import styles from './FileInputs.module.scss';
 const FileInputField: FieldArrayComponent<ReqSubmitJob, 'fileInputs'> = ({
   item,
   index,
-  remove
+  remove,
 }) => {
   const {
     register,

--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { useFormContext, FieldArrayPath } from 'react-hook-form';
-import { FileInput } from '@tapis/tapis-typescript-apps';
+import { useFormContext, FieldArray as TFieldArray } from 'react-hook-form';
 import { FieldArray, FieldArrayComponent } from './FieldArray';
 import FieldWrapper from 'tapis-ui/_common/FieldWrapper';
 import { Input, Label, FormText, FormGroup } from 'reactstrap';
 import { mapInnerRef } from 'tapis-ui/utils/forms';
 import { ReqSubmitJob } from '@tapis/tapis-typescript-jobs';
 
-const FileInputField: FieldArrayComponent<FileInput> = ({ item, index }) => {
+const FileInputField: FieldArrayComponent<ReqSubmitJob, 'fileInputs'> = ({
+  item,
+  index,
+}) => {
   const {
     register,
     formState: { errors },
@@ -68,13 +70,9 @@ const FileInputField: FieldArrayComponent<FileInput> = ({ item, index }) => {
   );
 };
 
-type FileInputsProps = {
-  inputs: Array<FileInput>;
-};
+type FileInput = TFieldArray<Required<ReqSubmitJob>, 'fileInputs'>;
 
-const FileInputs: React.FC<FileInputsProps> = ({ inputs }) => {
-  const name: FieldArrayPath<ReqSubmitJob> = 'fileInputs';
-
+const FileInputs: React.FC<{ inputs: FileInput[] }> = ({ inputs }) => {
   const required = Array.from(
     inputs.filter((fileInput) => fileInput?.meta?.required).keys()
   );
@@ -90,14 +88,16 @@ const FileInputs: React.FC<FileInputsProps> = ({ inputs }) => {
     },
   };
 
-  return FieldArray<FileInput>({
-    title: 'File Inputs',
-    addButtonText: 'Add File Input',
-    name,
-    render: FileInputField,
-    required,
-    appendData,
-  });
+  return (
+    <FieldArray<ReqSubmitJob, 'fileInputs'>
+      title="File Inputs"
+      addButtonText="Add File Input"
+      name="fileInputs"
+      render={FileInputField}
+      required={required}
+      appendData={appendData}
+    />
+  );
 };
 
 export default FileInputs;


### PR DESCRIPTION
## Overview:
ArrayField accepts 2 generic arguments `<TFieldValues, TArrayPath>` in line with how react-hook-form defines its own custom field types. `TFieldValues` is the overall form schema, e.g. `ReqSubmitJob` and `TArrayPath` is a string literal that describes the path to the field.
