### PR TITLE
task/TUI-159 - Distinguish between apps FileInput type and jobs InputSpec type

### DIFF
--- a/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FileInputs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useFormContext, FieldArrayPath } from 'react-hook-form';
 import { FileInput } from '@tapis/tapis-typescript-apps';
+import { InputSpec } from '@tapis/tapis-typescript-jobs';
 import { FieldArray, FieldArrayComponent } from './FieldArray';
 import FieldWrapper from 'tapis-ui/_common/FieldWrapper';
 import { Input, Label, FormText, FormGroup } from 'reactstrap';
@@ -9,7 +10,7 @@ import { ReqSubmitJob } from '@tapis/tapis-typescript-jobs';
 import { Button } from 'reactstrap';
 import styles from './FileInputs.module.scss';
 
-const FileInputField: FieldArrayComponent<FileInput> = ({
+const FileInputField: FieldArrayComponent<InputSpec> = ({
   item,
   index,
   remove,
@@ -90,7 +91,7 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
     appInputs.filter((fileInput) => fileInput?.meta?.required).keys()
   );
 
-  const appendData: FileInput = {
+  const appendData: InputSpec = {
     sourceUrl: '',
     targetPath: '',
     inPlace: false,
@@ -98,10 +99,11 @@ const FileInputs: React.FC<FileInputsProps> = ({ appInputs }) => {
       name: '',
       description: '',
       required: false,
+      kv: [],
     },
   };
 
-  return FieldArray<FileInput>({
+  return FieldArray<InputSpec>({
     title: 'File Inputs',
     addButtonText: 'Add File Input',
     name,

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncher.tsx
@@ -9,6 +9,8 @@ import { useDetail } from 'tapis-hooks/apps';
 import { SubmitWrapper, QueryWrapper } from 'tapis-ui/_wrappers';
 import { Button, Input } from 'reactstrap';
 import { mapInnerRef } from 'tapis-ui/utils/forms';
+import { FileInput } from '@tapis/tapis-typescript-apps';
+import { InputSpec } from '@tapis/tapis-typescript-jobs';
 import FileInputs from './FileInputs';
 
 export type OnSubmitCallback = (job: Jobs.Job) => any;
@@ -57,19 +59,38 @@ const JobLauncher: React.FC<JobLauncherProps> = ({
     formState: { errors },
   } = formMethods;
 
+  // Utility function to map an app spec's file inputs to a job's fileInput
+  const mapAppInputs = (appInputs: Array<FileInput>) => {
+    return appInputs.map((input) => {
+      const { sourceUrl, targetPath, inPlace, meta } = input;
+      const result: InputSpec = {
+        sourceUrl,
+        targetPath,
+        inPlace,
+      };
+      if (meta) {
+        const { keyValuePairs, ...rest } = meta;
+        result.meta = {
+          ...rest,
+          kv: keyValuePairs ?? [],
+        };
+      }
+      return result;
+    });
+  };
+
+  const defaultValues: Jobs.ReqSubmitJob = {
+    name,
+    appId,
+    appVersion,
+    execSystemId,
+    fileInputs: mapAppInputs(app?.result?.jobAttributes?.fileInputs ?? []),
+  };
+
   // Populating default values needs to happen as an effect
   // after initial render of field arrays
   useEffect(() => {
-    const tapisApp = app?.result;
-    if (tapisApp) {
-      reset({
-        name,
-        appId: tapisApp.id,
-        appVersion: tapisApp.version,
-        execSystemId,
-        fileInputs: tapisApp.jobAttributes?.fileInputs ?? [],
-      });
-    }
+    reset(defaultValues);
   }, [reset, app?.result?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (


### PR DESCRIPTION
## Overview:

Apps use the `FileInput` type, while Jobs uses `InputSpec`. Due to existing type discrepancies now and future type changes, apps FileInputs needs to be mapped to jobs InputSpecs.

## Related Github Issues:

- [TUI-159](https://github.com/tapis-project/tapis-ui/issues/159)

## Summary of Changes:

- Added mapping function from app file inputs to job input specs
- JobLauncher now uses a defaultValue structure
- FileInputs and FileInputFields use correct `InputSpec` type

## Testing Steps:

1.

## UI Photos:

## Notes:
