### PR TITLE
Task/t UI 159  field dictionaries

### DIFF
--- a/src/tapis-ui/components/jobs/JobLauncher/FieldDictionary.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/FieldDictionary.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  useFormContext,
+  Path,
+  UseFormSetValue
+} from 'react-hook-form';
+import { Button } from 'reactstrap';
+import { Collapse } from 'tapis-ui/_common';
+import styles from './FieldArray.module.scss';
+
+export type FieldDictionaryComponent<
+  TFieldValues,
+  TPath extends Path<TFieldValues>
+> = React.FC<{
+  key: string;
+  //item: FieldArrayWithId<Required<TFieldValues>, TArrayPath>;
+  value: any;
+  remove?: () => any;
+}>;
+
+type FieldDictionaryProps<
+  TFieldValues,
+  TPath extends Path<TFieldValues>
+> = {
+  // react-hook-form data ref
+  name: TPath;
+  // Title for collapse panel
+  title: string;
+  // Custom component to render field
+  render: FieldDictionaryComponent<TFieldValues, TPath>;
+  // Data template when appending new fields
+  appendData: any;
+  // react-hook-form control hook
+  addButtonText?: string;
+  required?: Array<number>;
+  isCollapsable?: boolean;
+};
+
+export function FieldDictionary<
+  TFieldValues,
+  TPath extends Path<Required<TFieldValues>>
+>({
+  name,
+  title,
+  render,
+  appendData,
+  addButtonText,
+  required = [],
+  isCollapsable = true,
+}: FieldDictionaryProps<Required<TFieldValues>, TPath>) {
+  const { setValue, getValues, register } = useFormContext<TFieldValues>();
+  const [ nextKey, setNextKey ] = useState(1);
+  useEffect(
+    () => {
+      register(name)
+    },
+    [ register, name ]
+  )
+
+  const values: any = { ... getValues(name) }; 
+
+  const addItem = useCallback(
+    () => {
+      let search = nextKey;
+      while (`key${search}` in values) {
+        search++;
+      }
+      values[`key${search}`] = appendData;
+      setValue(name, values);
+      setNextKey(search);
+    },
+    [ setValue, values, nextKey, setNextKey, name, appendData ]
+  ) 
+
+  return (
+    <div>
+      <Collapse
+        open={required.length > 0}
+        title={title}
+        isCollapsable={isCollapsable}
+      >
+        {
+          Object.entries(values).map(
+            ([key, value]) => { 
+              return render({ key, value });
+            }
+          )
+        }
+        <Button onClick={() => addItem()}>+</Button>
+      </Collapse>
+    </div>
+  );
+}

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncher2.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncher2.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect } from 'react';
+import { useList } from 'tapis-hooks/systems';
+import { useSubmit } from 'tapis-hooks/jobs';
+import { useForm, FormProvider } from 'react-hook-form';
+import FieldWrapper from 'tapis-ui/_common/FieldWrapper';
+import { TapisSystem } from '@tapis/tapis-typescript-systems';
+import { Jobs } from '@tapis/tapis-typescript';
+import { useDetail } from 'tapis-hooks/apps';
+import { SubmitWrapper, QueryWrapper } from 'tapis-ui/_wrappers';
+import { Button, Input } from 'reactstrap';
+import { mapInnerRef } from 'tapis-ui/utils/forms';
+import { FileInput } from '@tapis/tapis-typescript-apps';
+import { InputSpec } from '@tapis/tapis-typescript-jobs';
+import NamedFileInputs, { TestJobSpec } from './NamedFileInputs';
+import FileInputs from './FileInputs';
+
+export type OnSubmitCallback = (job: Jobs.Job) => any;
+
+interface JobLauncherProps {
+  appId: string;
+  appVersion: string;
+  name: string;
+  execSystemId?: string;
+}
+
+const JobLauncher: React.FC<JobLauncherProps> = ({
+  appId,
+  appVersion,
+  name,
+  execSystemId,
+}) => {
+  const {
+    data: systemsData,
+    isLoading: systemsLoading,
+    error: systemsError,
+  } = useList();
+  const systems: Array<TapisSystem> = systemsData?.result ?? [];
+  const {
+    data: app,
+    isLoading: appLoading,
+    error: appError,
+  } = useDetail({
+    appId,
+    appVersion,
+    select: 'jobAttributes',
+  });
+
+  /* eslint-disable-next-line */
+  const { submit, isLoading, error, data } = useSubmit(appId, appVersion);
+  const formSubmit = (values: TestJobSpec ) => {
+    //submit(values);
+    console.log(values);
+  };
+
+  const formMethods = useForm<TestJobSpec>();
+  const {
+    reset,
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = formMethods;
+
+  // Utility function to map an app spec's file inputs to a job's fileInput
+  const mapAppInputs = (appInputs: Array<FileInput>) => {
+    return appInputs.map((input) => {
+      const { sourceUrl, targetPath, inPlace, meta } = input;
+      const result: InputSpec = {
+        sourceUrl,
+        targetPath,
+        inPlace,
+      };
+      if (meta) {
+        const { keyValuePairs, ...rest } = meta;
+        result.meta = {
+          ...rest,
+          kv: keyValuePairs ?? [],
+        };
+      }
+      return result;
+    });
+  };
+
+  const defaultValues: TestJobSpec = {
+    namedFileInputs: {
+      "key1": { sourceUrl: "source1", targetPath: "target1" },
+      "key3": { sourceUrl: "source2", targetPath: "target2" }
+    }
+  };
+
+  // Populating default values needs to happen as an effect
+  // after initial render of field arrays
+  useEffect(() => {
+    reset(defaultValues);
+  }, [reset, app?.result?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <QueryWrapper
+      isLoading={appLoading || systemsLoading}
+      error={appError ?? systemsError}
+    >
+      <FormProvider {...formMethods}>
+        <form onSubmit={handleSubmit(formSubmit)}>
+          <NamedFileInputs />
+          {/* Submit button */}
+          <SubmitWrapper
+            error={error}
+            isLoading={isLoading}
+            success={
+              data && `Successfully submitted job ${data?.result?.uuid ?? ''}`
+            }
+          >
+            <Button
+              type="submit"
+              className="btn btn-primary"
+              disabled={isLoading || !!error}
+            >
+              Submit Job
+            </Button>
+          </SubmitWrapper>
+        </form>
+      </FormProvider>
+    </QueryWrapper>
+  );
+};
+
+export default JobLauncher;

--- a/src/tapis-ui/components/jobs/JobLauncher/NamedFileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/NamedFileInputs.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import { FieldDictionary, FieldDictionaryComponent } from './FieldDictionary';
+import { InputSpec } from '@tapis/tapis-typescript-jobs';
+
+export type TestJobSpec = {
+  namedFileInputs: {
+    [key: string]: InputSpec
+  }
+}
+
+const NamedFileComponent: FieldDictionaryComponent<TestJobSpec, 'namedFileInputs'> = ({ key, value, remove }) => {
+  return (
+    <div>{key}: {JSON.stringify(value)}</div>
+  )
+}
+
+const NamedFileInputs: React.FC = () => {
+  return (
+    <FieldDictionary<TestJobSpec, 'namedFileInputs'>
+      name="namedFileInputs"
+      render={NamedFileComponent}
+      title="Test Dictionary"
+      appendData={{sourceUrl: "newSource", targetPath: "newPath"}}
+    />
+  )
+}
+
+export default NamedFileInputs;

--- a/src/tapis-ui/components/jobs/JobLauncher/index.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/index.tsx
@@ -1,1 +1,1 @@
-export { default } from './JobLauncher';
+export { default } from './JobLauncher2';


### PR DESCRIPTION
## Overview:

Provisional implementation of FieldDictionary

- allows a user to add new objects
- needs to have the ability to set arbitrary key name (later)
- potentially will be used in FileInputs that have an object schema with names, rather than the current implementation where the files are an array of objects with names.

Test by selecting an App - it will render an alternate Job Launcher that only shows a dictionary with test objects. (Expand it, then try adding objects.)

## Related Github Issues:

- [TUI-1234](https://github.com/tapis-project/tapis-ui/issues/1234)

## Summary of Changes:

## Testing Steps:

1.

## UI Photos:

## Notes:
