### PR TITLE
task/TUI-205 -- files listing select all

### DIFF
--- a/src/tapis-app/Files/FileListing/_Layout/Layout.tsx
+++ b/src/tapis-app/Files/FileListing/_Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useEffect } from 'react';
 import { FileListing } from 'tapis-ui/components/files';
 import { PageLayout } from 'tapis-ui/_common';
 import { useFilesSelect } from 'tapis-app/Files/_components/FilesContext';
@@ -10,12 +10,11 @@ type LayoutProps = {
   location: string;
 };
 
-const Layout: React.FC<LayoutProps> = ({
-  systemId,
-  path,
-  location,
-}) => {
-  const { selectedFiles, select, unselect } = useFilesSelect();
+const Layout: React.FC<LayoutProps> = ({ systemId, path, location }) => {
+  const { selectedFiles, select, unselect, clear } = useFilesSelect();
+  useEffect(() => {
+    clear();
+  }, [systemId, path, clear]);
 
   const body = (
     <div className={styles.body}>
@@ -26,7 +25,7 @@ const Layout: React.FC<LayoutProps> = ({
         location={location}
         selectTypes={['dir', 'file']}
         selectedFiles={selectedFiles}
-        onSelect={(files) => select(files, 'multi') }
+        onSelect={(files) => select(files, 'multi')}
         onUnselect={unselect}
       ></FileListing>
     </div>

--- a/src/tapis-app/Files/FileListing/_Layout/Layout.tsx
+++ b/src/tapis-app/Files/FileListing/_Layout/Layout.tsx
@@ -17,6 +17,7 @@ const Layout: React.FC<LayoutProps> = ({
   onSelect,
 }) => {
   const body = (
+
     <div className={styles.body}>
       <FileListing
         className={styles.container}

--- a/src/tapis-app/Files/FileListing/_Layout/Layout.tsx
+++ b/src/tapis-app/Files/FileListing/_Layout/Layout.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { FileListing } from 'tapis-ui/components/files';
 import { PageLayout } from 'tapis-ui/_common';
-import { OnSelectCallback } from 'tapis-ui/components/files/FileListing/FileListing';
 import { useFilesSelect } from 'tapis-app/Files/_components/FilesContext';
 import styles from './Layout.module.scss';
 

--- a/src/tapis-app/Files/FileListing/_Layout/Layout.tsx
+++ b/src/tapis-app/Files/FileListing/_Layout/Layout.tsx
@@ -1,31 +1,34 @@
+import React, { useCallback } from 'react';
 import { FileListing } from 'tapis-ui/components/files';
 import { PageLayout } from 'tapis-ui/_common';
 import { OnSelectCallback } from 'tapis-ui/components/files/FileListing/FileListing';
+import { useFilesSelect } from 'tapis-app/Files/_components/FilesContext';
 import styles from './Layout.module.scss';
 
 type LayoutProps = {
   systemId: string;
   path: string;
   location: string;
-  onSelect: OnSelectCallback;
 };
 
 const Layout: React.FC<LayoutProps> = ({
   systemId,
   path,
   location,
-  onSelect,
 }) => {
-  const body = (
+  const { selectedFiles, select, unselect } = useFilesSelect();
 
+  const body = (
     <div className={styles.body}>
       <FileListing
         className={styles.container}
         systemId={systemId}
         path={path}
         location={location}
-        select={{ mode: 'multi' }}
-        onSelect={onSelect}
+        selectTypes={['dir', 'file']}
+        selectedFiles={selectedFiles}
+        onSelect={(files) => select(files, 'multi') }
+        onUnselect={unselect}
       ></FileListing>
     </div>
   );

--- a/src/tapis-app/Files/_Layout/Layout.tsx
+++ b/src/tapis-app/Files/_Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React from 'react';
 import {
   PageLayout,
   LayoutBody,

--- a/src/tapis-app/Files/_Layout/Layout.tsx
+++ b/src/tapis-app/Files/_Layout/Layout.tsx
@@ -12,16 +12,9 @@ import Toolbar from '../_components/Toolbar';
 import { useLocation } from 'react-router';
 import breadcrumbsFromPathname from 'tapis-ui/_common/Breadcrumbs/breadcrumbsFromPathname';
 import styles from './Layout.module.scss';
-import { Files } from '@tapis/tapis-typescript';
-import { OnSelectCallback } from 'tapis-ui/components/files/FileListing/FileListing';
+import { FilesProvider } from '../_components/FilesContext';
 
 const Layout: React.FC = () => {
-  const [selectedFiles, setSelectedFiles] = useState<Array<Files.FileInfo>>([]);
-  const onSelect = useCallback<OnSelectCallback>(
-    (files) => setSelectedFiles(files),
-    [setSelectedFiles]
-  );
-
   const { pathname } = useLocation();
 
   const header = (
@@ -34,7 +27,7 @@ const Layout: React.FC = () => {
           ]}
         />
       </div>
-      <Toolbar selectedFiles={selectedFiles} />
+      <Toolbar />
     </LayoutHeader>
   );
 
@@ -46,11 +39,15 @@ const Layout: React.FC = () => {
 
   const body = (
     <LayoutBody constrain>
-      <Router onSelect={onSelect} />
+      <Router />
     </LayoutBody>
   );
 
-  return <PageLayout top={header} left={sidebar} right={body} />;
+  return (
+    <FilesProvider>
+      <PageLayout top={header} left={sidebar} right={body} />
+    </FilesProvider>
+  );
 };
 
 export default Layout;

--- a/src/tapis-app/Files/_Router/Router.tsx
+++ b/src/tapis-app/Files/_Router/Router.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-router-dom';
 import FileListing from '../FileListing';
 import { SectionMessage } from 'tapis-ui/_common';
-import { OnSelectCallback } from 'tapis-ui/components/files/FileListing/FileListing';
+import { useFilesSelect } from '../_components/FilesContext';
 
 export const backLocation = (
   systemPath: string | undefined,
@@ -16,9 +16,11 @@ export const backLocation = (
 ) =>
   systemPath ? `${pathname.split('/').slice(0, -2).join('/')}/` : undefined;
 
-const Router: React.FC<{ onSelect: OnSelectCallback }> = ({ onSelect }) => {
+const Router: React.FC = () => {
   const { path } = useRouteMatch();
   const { pathname } = useLocation();
+  const { select } = useFilesSelect();
+
   return (
     <Switch>
       <Route path={`${path}`} exact>
@@ -39,7 +41,7 @@ const Router: React.FC<{ onSelect: OnSelectCallback }> = ({ onSelect }) => {
               systemId={systemId}
               path={systemPath ?? '/'}
               location={pathname}
-              onSelect={onSelect}
+              onSelect={select}
             />
           );
         }}

--- a/src/tapis-app/Files/_Router/Router.tsx
+++ b/src/tapis-app/Files/_Router/Router.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react-router-dom';
 import FileListing from '../FileListing';
 import { SectionMessage } from 'tapis-ui/_common';
-import { useFilesSelect } from '../_components/FilesContext';
 
 export const backLocation = (
   systemPath: string | undefined,
@@ -19,7 +18,6 @@ export const backLocation = (
 const Router: React.FC = () => {
   const { path } = useRouteMatch();
   const { pathname } = useLocation();
-  const { select } = useFilesSelect();
 
   return (
     <Switch>
@@ -41,7 +39,6 @@ const Router: React.FC = () => {
               systemId={systemId}
               path={systemPath ?? '/'}
               location={pathname}
-              onSelect={select}
             />
           );
         }}

--- a/src/tapis-app/Files/_components/FilesContext/FilesContext.tsx
+++ b/src/tapis-app/Files/_components/FilesContext/FilesContext.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { FilesContextType } from '.';
+
+export const filesContext: FilesContextType = {
+  selectedFiles: [],
+  setSelectedFiles: () => {}
+};
+
+const FilesContext: React.Context<FilesContextType> =
+  React.createContext<FilesContextType>(filesContext);
+
+export default FilesContext;

--- a/src/tapis-app/Files/_components/FilesContext/FilesContext.tsx
+++ b/src/tapis-app/Files/_components/FilesContext/FilesContext.tsx
@@ -3,7 +3,7 @@ import { FilesContextType } from '.';
 
 export const filesContext: FilesContextType = {
   selectedFiles: [],
-  setSelectedFiles: () => {}
+  setSelectedFiles: () => {},
 };
 
 const FilesContext: React.Context<FilesContextType> =

--- a/src/tapis-app/Files/_components/FilesContext/FilesProvider.tsx
+++ b/src/tapis-app/Files/_components/FilesContext/FilesProvider.tsx
@@ -4,13 +4,13 @@ import { FilesContextType } from '.';
 import FilesContext from './FilesContext';
 
 const FilesProvider: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
-  const [ selectedFiles, setSelectedFiles ] = useState<Array<Files.FileInfo>>([]);
+  const [selectedFiles, setSelectedFiles] = useState<Array<Files.FileInfo>>([]);
 
   // Provide a context state for the rest of the application, including
   // a way of modifying the state
   const contextValue: FilesContextType = {
     selectedFiles,
-    setSelectedFiles
+    setSelectedFiles,
   };
 
   return (

--- a/src/tapis-app/Files/_components/FilesContext/FilesProvider.tsx
+++ b/src/tapis-app/Files/_components/FilesContext/FilesProvider.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { Files } from '@tapis/tapis-typescript';
+import { FilesContextType } from '.';
+import FilesContext from './FilesContext';
+
+const FilesProvider: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
+  const [ selectedFiles, setSelectedFiles ] = useState<Array<Files.FileInfo>>([]);
+
+  // Provide a context state for the rest of the application, including
+  // a way of modifying the state
+  const contextValue: FilesContextType = {
+    selectedFiles,
+    setSelectedFiles
+  };
+
+  return (
+    <FilesContext.Provider value={contextValue}>
+      {children}
+    </FilesContext.Provider>
+  );
+};
+
+export default FilesProvider;

--- a/src/tapis-app/Files/_components/FilesContext/index.tsx
+++ b/src/tapis-app/Files/_components/FilesContext/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Files } from '@tapis/tapis-typescript';
+
+export type FilesContextType = {
+  selectedFiles: Array<Files.FileInfo>;
+  setSelectedFiles: (selectedFiles: Array<Files.FileInfo>) => void;
+};
+
+export { default as FilesContext } from './FilesContext';
+export { default as FilesProvider } from './FilesProvider';
+export { default as useFilesSelect } from './useFilesSelect';

--- a/src/tapis-app/Files/_components/FilesContext/index.tsx
+++ b/src/tapis-app/Files/_components/FilesContext/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Files } from '@tapis/tapis-typescript';
 
 export type FilesContextType = {

--- a/src/tapis-app/Files/_components/FilesContext/useFilesSelect.test.ts
+++ b/src/tapis-app/Files/_components/FilesContext/useFilesSelect.test.ts
@@ -1,0 +1,104 @@
+import  React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react';
+import { fileInfo } from 'fixtures/files.fixtures';
+import useFilesSelect from './useFilesSelect';
+
+
+const file1 = { ...fileInfo, path: '/file1.txt' }
+const file2 = { ...fileInfo, path: '/file2.txt' }
+const file3 = { ...fileInfo, path: '/file3.txt' }
+
+describe('useFilesSelect', () => {
+  it('performs single selection', async () => {
+    const selectedFiles = [ file1 ];
+    const setSelectedFiles = jest.fn();
+
+    const mockUseContext = jest.fn().mockImplementation(() => ({
+      selectedFiles, setSelectedFiles
+    }));
+    
+    React.useContext = mockUseContext;
+ 
+    const { result } = renderHook(() => useFilesSelect());
+    const { select } = result.current;
+
+    await act(async () => {
+      select([ file2 ], 'single');
+    });
+    expect(setSelectedFiles).toHaveBeenCalledWith([ file2 ])
+  });
+
+  it('performs single selection of a file already selected', async () => {
+    const selectedFiles = [ file1 ];
+    const setSelectedFiles = jest.fn();
+
+    const mockUseContext = jest.fn().mockImplementation(() => ({
+      selectedFiles, setSelectedFiles
+    }));
+    
+    React.useContext = mockUseContext;
+    const { result } = renderHook(() => useFilesSelect());
+    const { select } = result.current;
+
+    await act(async () => {
+      select([ file1 ], 'single');
+    });
+    expect(setSelectedFiles).toHaveBeenCalledWith([ file1 ]);
+  });
+
+  it('performs multiselection', async () => {
+    const selectedFiles = [ file1 ];
+    const setSelectedFiles = jest.fn();
+
+    const mockUseContext = jest.fn().mockImplementation(() => ({
+      selectedFiles, setSelectedFiles
+    }));
+    
+    React.useContext = mockUseContext;
+    const { result } = renderHook(() => useFilesSelect());
+    const { select } = result.current;
+
+    await act(async () => {
+      select([ file2 ], 'multi');
+    });
+    expect(setSelectedFiles).toHaveBeenCalledWith([ file1, file2 ]);
+  });
+
+  it('performs unselection', async () => {
+    const selectedFiles = [ file1, file2, file3 ];
+    const setSelectedFiles = jest.fn();
+
+    const mockUseContext = jest.fn().mockImplementation(() => ({
+      selectedFiles, setSelectedFiles
+    }));
+    
+    React.useContext = mockUseContext;
+    const { result } = renderHook(() => useFilesSelect());
+    const { unselect } = result.current;
+
+    await act(async () => {
+      unselect([ file2 ]);
+    });
+    expect(setSelectedFiles).toHaveBeenCalledWith([ file1, file3 ]);
+  });
+
+  it('performs clearing', async () => {
+    const selectedFiles = [ file1, file2 ];
+    const setSelectedFiles = jest.fn();
+
+    const mockUseContext = jest.fn().mockImplementation(() => ({
+      selectedFiles, setSelectedFiles
+    }));
+    
+    React.useContext = mockUseContext;
+    const { result } = renderHook(() => useFilesSelect());
+    const { clear } = result.current;
+
+    await act(async () => {
+      clear();
+    });
+    expect(setSelectedFiles).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/tapis-app/Files/_components/FilesContext/useFilesSelect.test.ts
+++ b/src/tapis-app/Files/_components/FilesContext/useFilesSelect.test.ts
@@ -1,97 +1,101 @@
-import  React from 'react';
+import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from '@testing-library/react';
 import { fileInfo } from 'fixtures/files.fixtures';
 import useFilesSelect from './useFilesSelect';
 
-
-const file1 = { ...fileInfo, path: '/file1.txt' }
-const file2 = { ...fileInfo, path: '/file2.txt' }
-const file3 = { ...fileInfo, path: '/file3.txt' }
+const file1 = { ...fileInfo, path: '/file1.txt' };
+const file2 = { ...fileInfo, path: '/file2.txt' };
+const file3 = { ...fileInfo, path: '/file3.txt' };
 
 describe('useFilesSelect', () => {
   it('performs single selection', async () => {
-    const selectedFiles = [ file1 ];
+    const selectedFiles = [file1];
     const setSelectedFiles = jest.fn();
 
     const mockUseContext = jest.fn().mockImplementation(() => ({
-      selectedFiles, setSelectedFiles
+      selectedFiles,
+      setSelectedFiles,
     }));
-    
+
     React.useContext = mockUseContext;
- 
+
     const { result } = renderHook(() => useFilesSelect());
     const { select } = result.current;
 
     await act(async () => {
-      select([ file2 ], 'single');
+      select([file2], 'single');
     });
-    expect(setSelectedFiles).toHaveBeenCalledWith([ file2 ])
+    expect(setSelectedFiles).toHaveBeenCalledWith([file2]);
   });
 
   it('performs single selection of a file already selected', async () => {
-    const selectedFiles = [ file1 ];
+    const selectedFiles = [file1];
     const setSelectedFiles = jest.fn();
 
     const mockUseContext = jest.fn().mockImplementation(() => ({
-      selectedFiles, setSelectedFiles
+      selectedFiles,
+      setSelectedFiles,
     }));
-    
+
     React.useContext = mockUseContext;
     const { result } = renderHook(() => useFilesSelect());
     const { select } = result.current;
 
     await act(async () => {
-      select([ file1 ], 'single');
+      select([file1], 'single');
     });
-    expect(setSelectedFiles).toHaveBeenCalledWith([ file1 ]);
+    expect(setSelectedFiles).toHaveBeenCalledWith([file1]);
   });
 
   it('performs multiselection', async () => {
-    const selectedFiles = [ file1 ];
+    const selectedFiles = [file1];
     const setSelectedFiles = jest.fn();
 
     const mockUseContext = jest.fn().mockImplementation(() => ({
-      selectedFiles, setSelectedFiles
+      selectedFiles,
+      setSelectedFiles,
     }));
-    
+
     React.useContext = mockUseContext;
     const { result } = renderHook(() => useFilesSelect());
     const { select } = result.current;
 
     await act(async () => {
-      select([ file2 ], 'multi');
+      select([file2], 'multi');
     });
-    expect(setSelectedFiles).toHaveBeenCalledWith([ file1, file2 ]);
+    expect(setSelectedFiles).toHaveBeenCalledWith([file1, file2]);
   });
 
   it('performs unselection', async () => {
-    const selectedFiles = [ file1, file2, file3 ];
+    const selectedFiles = [file1, file2, file3];
     const setSelectedFiles = jest.fn();
 
     const mockUseContext = jest.fn().mockImplementation(() => ({
-      selectedFiles, setSelectedFiles
+      selectedFiles,
+      setSelectedFiles,
     }));
-    
+
     React.useContext = mockUseContext;
     const { result } = renderHook(() => useFilesSelect());
     const { unselect } = result.current;
 
     await act(async () => {
-      unselect([ file2 ]);
+      unselect([file2]);
     });
-    expect(setSelectedFiles).toHaveBeenCalledWith([ file1, file3 ]);
+    expect(setSelectedFiles).toHaveBeenCalledWith([file1, file3]);
   });
 
   it('performs clearing', async () => {
-    const selectedFiles = [ file1, file2 ];
+    const selectedFiles = [file1, file2];
     const setSelectedFiles = jest.fn();
 
     const mockUseContext = jest.fn().mockImplementation(() => ({
-      selectedFiles, setSelectedFiles
+      selectedFiles,
+      setSelectedFiles,
     }));
-    
+
     React.useContext = mockUseContext;
     const { result } = renderHook(() => useFilesSelect());
     const { clear } = result.current;

--- a/src/tapis-app/Files/_components/FilesContext/useFilesSelect.ts
+++ b/src/tapis-app/Files/_components/FilesContext/useFilesSelect.ts
@@ -1,0 +1,31 @@
+import { useContext } from 'react';
+import { useQuery } from 'react-query';
+import React, { useCallback } from 'react';
+import FilesContext from './FilesContext';
+import { Files } from '@tapis/tapis-typescript';
+
+const useFilesSelect = () => {
+  const { selectedFiles, setSelectedFiles } = useContext(FilesContext);
+
+  const select = useCallback(
+    (files: Array<Files.FileInfo>) => {
+      setSelectedFiles(files);
+    },
+    [ selectedFiles, setSelectedFiles ]
+  )
+
+  const clearSelection = useCallback(
+    () => {
+      setSelectedFiles([]);
+    },
+    [ setSelectedFiles ]
+  )
+
+  return {
+    selectedFiles,
+    select,
+    clearSelection
+  };
+};
+
+export default useFilesSelect;

--- a/src/tapis-app/Files/_components/FilesContext/useFilesSelect.ts
+++ b/src/tapis-app/Files/_components/FilesContext/useFilesSelect.ts
@@ -1,6 +1,5 @@
 import { useContext } from 'react';
-import { useQuery } from 'react-query';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import FilesContext from './FilesContext';
 import { Files } from '@tapis/tapis-typescript';
 
@@ -9,41 +8,45 @@ const useFilesSelect = () => {
 
   const select = useCallback(
     (files: Array<Files.FileInfo>, mode: 'single' | 'multi') => {
-      if ( mode === 'single' && files.length === 1) {
+      if (mode === 'single' && files.length === 1) {
         setSelectedFiles(files);
       }
 
       if (mode === 'multi') {
-        const selectedSet = new Set(selectedFiles.map(file => file.path));
-        const newSelection = [ ...selectedFiles, ...files.filter(file => !selectedSet.has(file.path)) ];
+        const selectedSet = new Set(selectedFiles.map((file) => file.path));
+        const newSelection = [
+          ...selectedFiles,
+          ...files.filter((file) => !selectedSet.has(file.path)),
+        ];
         setSelectedFiles(newSelection);
       }
     },
-    [ selectedFiles, setSelectedFiles ]
-  )
-  
+    [selectedFiles, setSelectedFiles]
+  );
+
   const unselect = useCallback(
     (files: Array<Files.FileInfo>) => {
-      const selectedSet = new Set(selectedFiles.map(selected => selected.path));
-      files.forEach(file => selectedSet.delete(file.path ?? ''));
-      const newSelection = selectedFiles.filter(selected => selectedSet.has(selected.path));
+      const selectedSet = new Set(
+        selectedFiles.map((selected) => selected.path)
+      );
+      files.forEach((file) => selectedSet.delete(file.path ?? ''));
+      const newSelection = selectedFiles.filter((selected) =>
+        selectedSet.has(selected.path)
+      );
       setSelectedFiles(newSelection);
     },
-    [ selectedFiles, setSelectedFiles ]
-  )
+    [selectedFiles, setSelectedFiles]
+  );
 
-  const clear = useCallback(
-    () => {
-      setSelectedFiles([]);
-    },
-    [ setSelectedFiles ]
-  )
+  const clear = useCallback(() => {
+    setSelectedFiles([]);
+  }, [setSelectedFiles]);
 
   return {
     selectedFiles,
     select,
     unselect,
-    clear
+    clear,
   };
 };
 

--- a/src/tapis-app/Files/_components/FilesContext/useFilesSelect.ts
+++ b/src/tapis-app/Files/_components/FilesContext/useFilesSelect.ts
@@ -8,13 +8,31 @@ const useFilesSelect = () => {
   const { selectedFiles, setSelectedFiles } = useContext(FilesContext);
 
   const select = useCallback(
+    (files: Array<Files.FileInfo>, mode: 'single' | 'multi') => {
+      if ( mode === 'single' && files.length === 1) {
+        setSelectedFiles(files);
+      }
+
+      if (mode === 'multi') {
+        const selectedSet = new Set(selectedFiles.map(file => file.path));
+        const newSelection = [ ...selectedFiles, ...files.filter(file => !selectedSet.has(file.path)) ];
+        setSelectedFiles(newSelection);
+      }
+    },
+    [ selectedFiles, setSelectedFiles ]
+  )
+  
+  const unselect = useCallback(
     (files: Array<Files.FileInfo>) => {
-      setSelectedFiles(files);
+      const selectedSet = new Set(selectedFiles.map(selected => selected.path));
+      files.forEach(file => selectedSet.delete(file.path ?? ''));
+      const newSelection = selectedFiles.filter(selected => selectedSet.has(selected.path));
+      setSelectedFiles(newSelection);
     },
     [ selectedFiles, setSelectedFiles ]
   )
 
-  const clearSelection = useCallback(
+  const clear = useCallback(
     () => {
       setSelectedFiles([]);
     },
@@ -24,7 +42,8 @@ const useFilesSelect = () => {
   return {
     selectedFiles,
     select,
-    clearSelection
+    unselect,
+    clear
   };
 };
 

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.test.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.test.tsx
@@ -5,9 +5,11 @@ import { useCopy, useMove, useList } from 'tapis-hooks/files';
 import { useMutations } from 'tapis-hooks/utils';
 import { fileInfo } from 'fixtures/files.fixtures';
 import { Files } from '@tapis/tapis-typescript';
+import { useFilesSelect } from 'tapis-app/Files/_components/FilesContext';
 
 jest.mock('tapis-hooks/utils');
 jest.mock('tapis-hooks/files');
+jest.mock('tapis-app/Files/_components/FilesContext');
 
 const selectedFiles: Array<Files.FileInfo> = [
   { ...fileInfo, name: 'targetFile.txt' },
@@ -36,12 +38,15 @@ describe('CopyMoveModal', () => {
       moveAsync: mockMoveAsync,
     });
 
+    (useFilesSelect as jest.Mock).mockReturnValue({
+      selectedFiles: [fileInfo]
+    })
+
     renderComponent(
       <CopyMoveModal
         toggle={() => {}}
         systemId={'system-id'}
         path={'/'}
-        selectedFiles={selectedFiles}
         operation={Files.MoveCopyRequestOperationEnum.Copy}
       />
     );
@@ -84,12 +89,15 @@ describe('CopyMoveModal', () => {
       moveAsync: mockMoveAsync,
     });
 
+    (useFilesSelect as jest.Mock).mockReturnValue({
+      selectedFiles: [fileInfo]
+    })
+
     renderComponent(
       <CopyMoveModal
         toggle={() => {}}
         systemId={'system-id'}
         path={'/'}
-        selectedFiles={selectedFiles}
         operation={Files.MoveCopyRequestOperationEnum.Move}
       />
     );

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.test.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.test.tsx
@@ -11,10 +11,6 @@ jest.mock('tapis-hooks/utils');
 jest.mock('tapis-hooks/files');
 jest.mock('tapis-app/Files/_components/FilesContext');
 
-const selectedFiles: Array<Files.FileInfo> = [
-  { ...fileInfo, name: 'targetFile.txt' },
-];
-
 describe('CopyMoveModal', () => {
   it('performs copy operations', async () => {
     (useList as jest.Mock).mockReturnValue({
@@ -39,8 +35,8 @@ describe('CopyMoveModal', () => {
     });
 
     (useFilesSelect as jest.Mock).mockReturnValue({
-      selectedFiles: [fileInfo]
-    })
+      selectedFiles: [fileInfo],
+    });
 
     renderComponent(
       <CopyMoveModal
@@ -90,8 +86,8 @@ describe('CopyMoveModal', () => {
     });
 
     (useFilesSelect as jest.Mock).mockReturnValue({
-      selectedFiles: [fileInfo]
-    })
+      selectedFiles: [fileInfo],
+    });
 
     renderComponent(
       <CopyMoveModal

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
@@ -34,7 +34,7 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
   const { pathname } = useLocation();
   const [copyMoveError, setCopyMoveError] = useState<Error | null>(null);
   const [destinationPath, setDestinationPath] = useState<string | null>(path);
-  const { selectedFiles } = useFilesSelect();
+  const { selectedFiles, unselect } = useFilesSelect();
 
   type CopyMoveState = {
     [path: string]: string;
@@ -60,8 +60,14 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
   const onFileCopyMoveSuccess = useCallback(
     (operation: CopyMoveHookParams, data: Files.FileStringResponse) => {
       dispatch({ path: operation.path, icon: 'approved-reverse' });
+      const fileInfo = selectedFiles.find(
+        (file) => file.path === operation.path
+      );
+      if (fileInfo) {
+        unselect([fileInfo]);
+      }
     },
-    [dispatch]
+    [dispatch, selectedFiles, unselect]
   );
   const onFileCopyMoveError = useCallback(
     (operation: CopyMoveHookParams, error: Error) => {

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
@@ -19,6 +19,7 @@ import { Files } from '@tapis/tapis-typescript';
 import { useMutations } from 'tapis-hooks/utils';
 import { Column } from 'react-table';
 import styles from './CopyMoveModal.module.scss';
+import { useFilesSelect } from '../../FilesContext';
 
 type CopyMoveModalProps = {
   operation: Files.MoveCopyRequestOperationEnum;
@@ -28,12 +29,12 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
   toggle,
   systemId = '',
   path = '/',
-  selectedFiles = [],
   operation,
 }) => {
   const { pathname } = useLocation();
   const [copyMoveError, setCopyMoveError] = useState<Error | null>(null);
   const [destinationPath, setDestinationPath] = useState<string | null>(path);
+  const { selectedFiles } = useFilesSelect();
 
   type CopyMoveState = {
     [path: string]: string;

--- a/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.test.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.test.tsx
@@ -3,13 +3,13 @@ import renderComponent from 'utils/testing';
 import RenameModal from './RenameModal';
 import { useMove } from 'tapis-hooks/files';
 import { fileInfo } from 'fixtures/files.fixtures';
-import { Files } from '@tapis/tapis-typescript';
+import { useFilesSelect } from 'tapis-app/Files/_components/FilesContext';
 
 jest.mock('tapis-hooks/files/useMove');
-
-const selectedFiles: Array<Files.FileInfo> = [fileInfo];
+jest.mock('tapis-app/Files/_components/FilesContext');
 
 describe('RenameModal', () => {
+
   it('submits with valid inputs', async () => {
     const moveMock = jest.fn();
     const resetMock = jest.fn();
@@ -20,13 +20,15 @@ describe('RenameModal', () => {
       isSuccess: false,
       reset: resetMock,
     });
+    (useFilesSelect as jest.Mock).mockReturnValue({
+      selectedFiles: [fileInfo]
+    })
 
     renderComponent(
       <RenameModal
         toggle={() => {}}
         systemId={'system-id'}
         path={'/'}
-        selectedFiles={selectedFiles}
       />
     );
 
@@ -58,13 +60,15 @@ describe('RenameModal', () => {
       isSuccess: false,
       reset: resetMock,
     });
+    (useFilesSelect as jest.Mock).mockReturnValue({
+      selectedFiles: [fileInfo]
+    })
 
     renderComponent(
       <RenameModal
         toggle={() => {}}
         systemId={'system-id'}
         path={'/'}
-        selectedFiles={selectedFiles}
       />
     );
 

--- a/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.test.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.test.tsx
@@ -9,7 +9,6 @@ jest.mock('tapis-hooks/files/useMove');
 jest.mock('tapis-app/Files/_components/FilesContext');
 
 describe('RenameModal', () => {
-
   it('submits with valid inputs', async () => {
     const moveMock = jest.fn();
     const resetMock = jest.fn();
@@ -21,15 +20,11 @@ describe('RenameModal', () => {
       reset: resetMock,
     });
     (useFilesSelect as jest.Mock).mockReturnValue({
-      selectedFiles: [fileInfo]
-    })
+      selectedFiles: [fileInfo],
+    });
 
     renderComponent(
-      <RenameModal
-        toggle={() => {}}
-        systemId={'system-id'}
-        path={'/'}
-      />
+      <RenameModal toggle={() => {}} systemId={'system-id'} path={'/'} />
     );
 
     const input = screen.getByLabelText('Input');
@@ -61,15 +56,11 @@ describe('RenameModal', () => {
       reset: resetMock,
     });
     (useFilesSelect as jest.Mock).mockReturnValue({
-      selectedFiles: [fileInfo]
-    })
+      selectedFiles: [fileInfo],
+    });
 
     renderComponent(
-      <RenameModal
-        toggle={() => {}}
-        systemId={'system-id'}
-        path={'/'}
-      />
+      <RenameModal toggle={() => {}} systemId={'system-id'} path={'/'} />
     );
 
     const input = screen.getByLabelText('Input');

--- a/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.tsx
@@ -14,14 +14,15 @@ const RenameModal: React.FC<ToolbarModalProps> = ({
   systemId,
   path,
 }) => {
-  const { selectedFiles } = useFilesSelect();
+  const { selectedFiles, clear } = useFilesSelect();
   const file = selectedFiles![0];
 
   const onSuccess = useCallback(() => {
     // Calling the focus manager triggers react-query's
     // automatic refetch on window focus
+    clear();
     focusManager.setFocused(true);
-  }, []);
+  }, [clear]);
 
   const { move, isLoading, error, isSuccess, reset } = useMove();
 

--- a/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { Button, Input } from 'reactstrap';
 import { GenericModal, FieldWrapper } from 'tapis-ui/_common';
 import { SubmitWrapper } from 'tapis-ui/_wrappers';
@@ -15,7 +15,8 @@ const RenameModal: React.FC<ToolbarModalProps> = ({
   path,
 }) => {
   const { selectedFiles, clear } = useFilesSelect();
-  const file = selectedFiles![0];
+  const [inputName, setInputName] = useState<string>();
+  const file = selectedFiles ? selectedFiles[0] : undefined;
 
   const onSuccess = useCallback(() => {
     // Calling the focus manager triggers react-query's
@@ -36,7 +37,7 @@ const RenameModal: React.FC<ToolbarModalProps> = ({
     formState: { errors },
   } = useForm({
     defaultValues: {
-      newname: file.name,
+      newname: file?.name ?? inputName ?? '',
     },
   });
 
@@ -54,16 +55,23 @@ const RenameModal: React.FC<ToolbarModalProps> = ({
     disabled: isSuccess,
   });
 
-  const onSubmit = ({ newname }: { newname: string }) => {
-    move(
-      {
-        systemId: systemId!,
-        path: `${path}${file.name}`,
-        newPath: `${path}${newname}`,
-      },
-      { onSuccess }
-    );
-  };
+  const onSubmit = useCallback(
+    ({ newname }: { newname: string }) => {
+      setInputName(newname);
+      if (!file?.name) {
+        return;
+      }
+      move(
+        {
+          systemId: systemId!,
+          path: `${path}${file!.name}`,
+          newPath: `${path}${newname}`,
+        },
+        { onSuccess }
+      );
+    },
+    [setInputName, file, move, onSuccess, systemId, path]
+  );
 
   const dirOrFile = (type: string | undefined) => {
     return type === 'dir' ? 'directory' : 'file';
@@ -72,19 +80,17 @@ const RenameModal: React.FC<ToolbarModalProps> = ({
   return (
     <GenericModal
       toggle={toggle}
-      title={`Rename ${dirOrFile(file.type)}`}
+      title={`Rename ${dirOrFile(file?.type)}`}
       body={
         <div>
           <form id="rename-form" onSubmit={handleSubmit(onSubmit)}>
             <FieldWrapper
               label={`${
-                dirOrFile(file.type).charAt(0).toUpperCase() +
-                dirOrFile(file.type).slice(1)
+                dirOrFile(file?.type).charAt(0).toUpperCase() +
+                dirOrFile(file?.type).slice(1)
               } Name`}
               required={true}
-              description={`Rename ${dirOrFile(file.type)} '${
-                file.name
-              }' in path '${path === '' ? '/' : path}'`}
+              description="Rename File"
               error={errors['newname']}
             >
               <Input

--- a/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/RenameModal/RenameModal.tsx
@@ -7,13 +7,14 @@ import { useForm } from 'react-hook-form';
 import { useMove } from 'tapis-hooks/files';
 import { focusManager } from 'react-query';
 import { useEffect } from 'react';
+import { useFilesSelect } from '../../FilesContext';
 
 const RenameModal: React.FC<ToolbarModalProps> = ({
   toggle,
   systemId,
   path,
-  selectedFiles,
 }) => {
+  const { selectedFiles } = useFilesSelect();
   const file = selectedFiles![0];
 
   const onSuccess = useCallback(() => {

--- a/src/tapis-app/Files/_components/Toolbar/Toolbar.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/Toolbar.tsx
@@ -7,6 +7,7 @@ import CreateDirModal from './CreateDirModal';
 import CopyMoveModal from './CopyMoveModal';
 import RenameModal from './RenameModal';
 import { useLocation } from 'react-router-dom';
+import { useFilesSelect } from '../FilesContext';
 
 type ToolbarButtonProps = {
   text: string;
@@ -17,7 +18,6 @@ type ToolbarButtonProps = {
 
 export type ToolbarModalProps = {
   toggle: () => void;
-  selectedFiles?: Array<Files.FileInfo>;
   systemId?: string;
   path?: string;
 };
@@ -42,10 +42,9 @@ export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
   );
 };
 
-const Toolbar: React.FC<{ selectedFiles: Array<Files.FileInfo> }> = ({
-  selectedFiles,
-}) => {
+const Toolbar: React.FC = () => {
   const [modal, setModal] = useState<string | undefined>(undefined);
+  const { selectedFiles } = useFilesSelect();
   const { pathname } = useLocation();
   const systemId = pathname.split('/')[2];
   const currentPath = pathname.split('/').splice(3).join('/');
@@ -119,7 +118,6 @@ const Toolbar: React.FC<{ selectedFiles: Array<Files.FileInfo> }> = ({
               toggle={toggle}
               systemId={systemId}
               path={currentPath}
-              selectedFiles={selectedFiles}
               operation={Files.MoveCopyRequestOperationEnum.Copy}
             />
           )}
@@ -128,14 +126,12 @@ const Toolbar: React.FC<{ selectedFiles: Array<Files.FileInfo> }> = ({
               toggle={toggle}
               systemId={systemId}
               path={currentPath}
-              selectedFiles={selectedFiles}
               operation={Files.MoveCopyRequestOperationEnum.Move}
             />
           )}
           {modal === 'rename' && (
             <RenameModal
               toggle={toggle}
-              selectedFiles={selectedFiles}
               systemId={systemId}
               path={currentPath}
             />

--- a/src/tapis-app/Files/_components/Toolbar/_components/FileExplorer/FileExplorer.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/_components/FileExplorer/FileExplorer.tsx
@@ -97,7 +97,6 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
             className={`${styles['file-list']} ${styles['nav-list']}`}
             systemId={currentSystem}
             path={currentPath ?? '/'}
-            select={{ mode: 'none' }}
             onNavigate={onFileNavigate}
             fields={['size']}
           />

--- a/src/tapis-ui/components/files/FileListing/FileListing.module.scss
+++ b/src/tapis-ui/components/files/FileListing/FileListing.module.scss
@@ -220,3 +220,11 @@
   padding-bottom: 0 !important;
   font-size: 1em !important;
 }
+
+.selected {
+  background-color: var(--global-color-accent--weak) !important;
+}
+
+.select-all {
+  margin-left: 2px;
+}

--- a/src/tapis-ui/components/files/FileListing/FileListing.module.scss
+++ b/src/tapis-ui/components/files/FileListing/FileListing.module.scss
@@ -226,5 +226,8 @@
 }
 
 .select-all {
-  margin-left: 2px;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  margin-top: 2px;
 }

--- a/src/tapis-ui/components/files/FileListing/FileListing.test.tsx
+++ b/src/tapis-ui/components/files/FileListing/FileListing.test.tsx
@@ -4,6 +4,7 @@ import renderComponent from 'utils/testing';
 import FileListing from './FileListing';
 import { useList } from 'tapis-hooks/files';
 import { fileInfo } from 'fixtures/files.fixtures';
+import { Files } from '@tapis/tapis-typescript';
 
 jest.mock('tapis-hooks/files');
 
@@ -24,9 +25,7 @@ describe('Files', () => {
 
   it('performs file selection', () => {
     (useList as jest.Mock).mockReturnValue({
-      concatenatedResults: [
-        { ...fileInfo }
-      ],
+      concatenatedResults: [{ ...fileInfo }],
       isLoading: false,
       error: null,
     });
@@ -38,7 +37,7 @@ describe('Files', () => {
         selectTypes={['dir', 'file']}
         onSelect={mockOnSelect}
       />
-    ); 
+    );
     // Find the file1.txt and file2.txt rows
     const file1 = getByTestId('file1.txt');
     expect(file1).toBeDefined();
@@ -50,9 +49,7 @@ describe('Files', () => {
 
   it('performs file unselection', () => {
     (useList as jest.Mock).mockReturnValue({
-      concatenatedResults: [
-        { ...fileInfo }
-      ],
+      concatenatedResults: [{ ...fileInfo }],
       isLoading: false,
       error: null,
     });
@@ -65,7 +62,7 @@ describe('Files', () => {
         selectedFiles={[fileInfo]}
         onUnselect={mockOnUnselect}
       />
-    ); 
+    );
     // Find the file1.txt and file2.txt rows
     const file1 = getByTestId('file1.txt');
     expect(file1).toBeDefined();
@@ -75,139 +72,37 @@ describe('Files', () => {
     expect(mockOnUnselect).toHaveBeenLastCalledWith([fileInfo]);
   });
 
-/*
-  it('performs multiple file selection', () => {
-    (useList as jest.Mock).mockReturnValue({
-      concatenatedResults: [
-        { ...fileInfo },
-        { ...fileInfo, name: 'file2.txt' },
-      ],
-      isLoading: false,
-      error: null,
-    });
-    const spy = jest.fn();
-    const { getByTestId } = renderComponent(
-      <FileListing
-        systemId={'system'}
-        path={'/'}
-        select={{ mode: 'multi' }}
-        onSelect={spy}
-      />
-    );
-    // Find the file1.txt and file2.txt rows
-    const file1 = getByTestId('file1.txt');
-    const file2 = getByTestId('file2.txt');
-    expect(file1).toBeDefined();
-    expect(file2).toBeDefined();
-
-    // Click on file1.txt and expect the callback to have run
-    file1.click();
-    expect(spy).toHaveBeenLastCalledWith([{ ...fileInfo }]);
-
-    // Click on file2.txt and expect the callback to have been called with both items
-    file2.click();
-    expect(spy).toHaveBeenLastCalledWith([
+  it('performs select all', () => {
+    const concatenatedResults: Array<Files.FileInfo> = [
       { ...fileInfo },
       { ...fileInfo, name: 'file2.txt' },
-    ]);
-
-    // Click on file1.txt again and expect the file to be "unselected"
-    file1.click();
-    expect(spy).toHaveBeenLastCalledWith([{ ...fileInfo, name: 'file2.txt' }]);
-  });
-
-  it('performs single file selection', () => {
+    ];
     (useList as jest.Mock).mockReturnValue({
-      concatenatedResults: [
-        { ...fileInfo },
-        { ...fileInfo, name: 'file2.txt' },
-      ],
+      concatenatedResults,
       isLoading: false,
       error: null,
     });
-    const spy = jest.fn();
+    const mockOnSelect = jest.fn();
+    const mockOnUnselect = jest.fn();
     const { getByTestId } = renderComponent(
       <FileListing
         systemId={'system'}
         path={'/'}
-        select={{ mode: 'single', types: ['file'] }}
-        onSelect={spy}
+        selectTypes={['dir', 'file']}
+        selectedFiles={[fileInfo]}
+        onSelect={mockOnSelect}
+        onUnselect={mockOnUnselect}
       />
     );
-
     // Find the file1.txt and file2.txt rows
-    const file1 = getByTestId('file1.txt');
-    const file2 = getByTestId('file2.txt');
-    expect(file1).toBeDefined();
-    expect(file2).toBeDefined();
+    const selectAll = getByTestId('select-all');
+    expect(selectAll).toBeDefined();
 
-    // Click on file1.txt and expect the callback to have run
-    file1.click();
-    expect(spy).toHaveBeenLastCalledWith([{ ...fileInfo }]);
+    // Click on file1.txt and expect the unselect callback to have run
+    selectAll.click();
+    expect(mockOnSelect).toHaveBeenCalledWith(concatenatedResults);
 
-    // Click on file2.txt and expect the callback to have been called with both items
-    file2.click();
-    expect(spy).toHaveBeenLastCalledWith([{ ...fileInfo, name: 'file2.txt' }]);
+    selectAll.click();
+    expect(mockOnUnselect).toHaveBeenCalledWith(concatenatedResults);
   });
-
-  it('should not allow selection of invalid file types', () => {
-    (useList as jest.Mock).mockReturnValue({
-      concatenatedResults: [
-        { ...fileInfo },
-        { ...fileInfo, type: 'dir', name: 'dir1' },
-      ],
-      isLoading: false,
-      error: null,
-    });
-    const spy = jest.fn();
-
-    // Create a FilesListing that disallows selection of any type
-    const { getByTestId } = renderComponent(
-      <FileListing
-        systemId={'system'}
-        path={'/'}
-        select={{ mode: 'single', types: [] }}
-        onSelect={spy}
-      />
-    );
-    const file1 = getByTestId('file1.txt');
-    const dir1 = getByTestId('dir1');
-    expect(file1).toBeDefined();
-    expect(dir1).toBeDefined();
-
-    // The only callback should be the initial render when trying to click a disallowed type
-    file1.click();
-    expect(spy).toHaveBeenCalledTimes(1);
-
-    dir1.click();
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  it('should not allow selection of files if select is undefined', () => {
-    (useList as jest.Mock).mockReturnValue({
-      concatenatedResults: [
-        { ...fileInfo },
-        { ...fileInfo, type: 'dir', name: 'dir1' },
-      ],
-      isLoading: false,
-      error: null,
-    });
-    const spy = jest.fn();
-
-    // Create a FilesListing that disallows selection of any type
-    const { getByTestId } = renderComponent(
-      <FileListing systemId={'system'} path={'/'} onSelect={spy} />
-    );
-    const file1 = getByTestId('file1.txt');
-    const dir1 = getByTestId('dir1');
-    expect(file1).toBeDefined();
-    expect(dir1).toBeDefined();
-
-    // The only callback should be the initial render
-    file1.click();
-    expect(spy).toHaveBeenCalledTimes(1);
-    dir1.click();
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-  */
 });

--- a/src/tapis-ui/components/files/FileListing/FileListing.test.tsx
+++ b/src/tapis-ui/components/files/FileListing/FileListing.test.tsx
@@ -21,7 +21,7 @@ describe('Files', () => {
     expect(getAllByText(/01\/01\/2020/).length).toEqual(1);
     expect(getAllByText(/29.3 kB/).length).toEqual(1);
   });
-
+/*
   it('performs multiple file selection', () => {
     (useList as jest.Mock).mockReturnValue({
       concatenatedResults: [
@@ -155,4 +155,5 @@ describe('Files', () => {
     dir1.click();
     expect(spy).toHaveBeenCalledTimes(1);
   });
+  */
 });

--- a/src/tapis-ui/components/files/FileListing/FileListing.test.tsx
+++ b/src/tapis-ui/components/files/FileListing/FileListing.test.tsx
@@ -21,6 +21,60 @@ describe('Files', () => {
     expect(getAllByText(/01\/01\/2020/).length).toEqual(1);
     expect(getAllByText(/29.3 kB/).length).toEqual(1);
   });
+
+  it('performs file selection', () => {
+    (useList as jest.Mock).mockReturnValue({
+      concatenatedResults: [
+        { ...fileInfo }
+      ],
+      isLoading: false,
+      error: null,
+    });
+    const mockOnSelect = jest.fn();
+    const { getByTestId } = renderComponent(
+      <FileListing
+        systemId={'system'}
+        path={'/'}
+        selectTypes={['dir', 'file']}
+        onSelect={mockOnSelect}
+      />
+    ); 
+    // Find the file1.txt and file2.txt rows
+    const file1 = getByTestId('file1.txt');
+    expect(file1).toBeDefined();
+
+    // Click on file1.txt and expect the select callback to have run
+    file1.click();
+    expect(mockOnSelect).toHaveBeenLastCalledWith([fileInfo]);
+  });
+
+  it('performs file unselection', () => {
+    (useList as jest.Mock).mockReturnValue({
+      concatenatedResults: [
+        { ...fileInfo }
+      ],
+      isLoading: false,
+      error: null,
+    });
+    const mockOnUnselect = jest.fn();
+    const { getByTestId } = renderComponent(
+      <FileListing
+        systemId={'system'}
+        path={'/'}
+        selectTypes={['dir', 'file']}
+        selectedFiles={[fileInfo]}
+        onUnselect={mockOnUnselect}
+      />
+    ); 
+    // Find the file1.txt and file2.txt rows
+    const file1 = getByTestId('file1.txt');
+    expect(file1).toBeDefined();
+
+    // Click on file1.txt and expect the unselect callback to have run
+    file1.click();
+    expect(mockOnUnselect).toHaveBeenLastCalledWith([fileInfo]);
+  });
+
 /*
   it('performs multiple file selection', () => {
     (useList as jest.Mock).mockReturnValue({


### PR DESCRIPTION
## Overview:

Implement Select All feature for files listing

## Related Github Issues:

- [TUI-205](https://github.com/tapis-project/tapis-ui/issues/205)

## Summary of Changes:

- Implemented a select all header checkbox for tapis-ui/FilesListing
- Implemented a tapis-app level FilesListing provider and useFilesSelect hook
- tapis-ui/FilesListing selection now calls back to client and allows it to use its own file selection management (in this case useFilesSelect hook)
- Modals use unselect and clear (from useFilesSelect hook) on successful operations to clear file selections for filenames that have changed
- tapis-ui/FilesListing selection highlights

## Testing Steps:

1. select files
2. Try select all/unselect all
3. Try navigation 
4. Try modals

## UI Photos:

## Notes:

- Requires exhaustive testing!!!
- Improved selection speed and re-rendering
- Upon infinite scroll, new files will be added to the filelisting that are unselected. This is intentional - "auto selecting" new files on infinite scroll would imply that all files in the current folder are selected for operations even if they are not visible.