### PR TITLE
task/TUI-213 - Unit tests for Toolbar

### DIFF
--- a/src/tapis-app/Files/_components/Toolbar/Toolbar.test.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/Toolbar.test.tsx
@@ -1,0 +1,80 @@
+import { act } from '@testing-library/react';
+import renderComponent from 'utils/testing';
+import Toolbar from './Toolbar';
+import { fileInfo } from 'fixtures/files.fixtures';
+import { useFilesSelect } from 'tapis-app/Files/_components/FilesContext';
+import RenameModal from 'tapis-app/Files/_components/Toolbar/RenameModal';
+
+jest.mock('tapis-hooks/files');
+jest.mock('tapis-app/Files/_components/FilesContext');
+jest.mock('tapis-app/Files/_components/Toolbar/RenameModal');
+
+describe('Toolbar', () => {
+  it('enables rename and download buttons', async () => {
+    (useFilesSelect as jest.Mock).mockReturnValue({
+      selectedFiles: [fileInfo],
+    });
+
+    (RenameModal as jest.Mock).mockReturnValue(<div></div>);
+
+    const { getByLabelText } = renderComponent(<Toolbar />);
+
+    const renameBtn = getByLabelText('Rename');
+    expect(renameBtn).toBeDefined();
+    expect(renameBtn.closest('button')).not.toHaveAttribute('disabled');
+
+    const downloadBtn = getByLabelText('Download');
+    expect(downloadBtn).toBeDefined();
+    expect(downloadBtn.closest('button')).not.toHaveAttribute('disabled');
+
+    // Try clicking the rename button
+    await act(async () => {
+      renameBtn.click();
+    });
+    expect(RenameModal as jest.Mock).toHaveBeenCalled();
+  });
+
+  it('disables download button for directories', async () => {
+    (useFilesSelect as jest.Mock).mockReturnValue({
+      selectedFiles: [{ ...fileInfo, type: 'dir' }],
+    });
+
+    const { getByLabelText } = renderComponent(<Toolbar />);
+
+    const downloadBtn = getByLabelText('Download');
+    expect(downloadBtn).toBeDefined();
+    expect(downloadBtn.closest('button')).toHaveAttribute('disabled');
+  });
+
+  it('disables download button for multiple file selection', async () => {
+    (useFilesSelect as jest.Mock).mockReturnValue({
+      selectedFiles: [fileInfo, fileInfo],
+    });
+
+    const { getByLabelText } = renderComponent(<Toolbar />);
+
+    const downloadBtn = getByLabelText('Download');
+    expect(downloadBtn).toBeDefined();
+    expect(downloadBtn.closest('button')).toHaveAttribute('disabled');
+  });
+
+  it('enables the move, copy and trash buttons', async () => {
+    (useFilesSelect as jest.Mock).mockReturnValue({
+      selectedFiles: [fileInfo, { ...fileInfo, type: 'dir' }],
+    });
+
+    const { getByLabelText } = renderComponent(<Toolbar />);
+
+    const moveBtn = getByLabelText('Move');
+    expect(moveBtn).toBeDefined();
+    expect(moveBtn.closest('button')).not.toHaveAttribute('disabled');
+
+    const copyBtn = getByLabelText('Copy');
+    expect(copyBtn).toBeDefined();
+    expect(copyBtn.closest('button')).not.toHaveAttribute('disabled');
+
+    const trashBtn = getByLabelText('Trash');
+    expect(trashBtn).toBeDefined();
+    expect(trashBtn.closest('button')).not.toHaveAttribute('disabled');
+  });
+});

--- a/src/tapis-app/Files/_components/Toolbar/Toolbar.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/Toolbar.tsx
@@ -27,6 +27,7 @@ export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
   icon,
   onClick,
   disabled = true,
+  ...rest
 }) => {
   return (
     <div>
@@ -34,6 +35,7 @@ export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
         disabled={disabled}
         onClick={onClick}
         className={styles['toolbar-btn']}
+        {...rest}
       >
         <Icon name={icon}></Icon>
         <span> {text}</span>
@@ -60,18 +62,21 @@ const Toolbar: React.FC = () => {
             icon="rename"
             disabled={selectedFiles.length !== 1}
             onClick={() => setModal('rename')}
+            aria-label="Rename"
           />
           <ToolbarButton
             text="Move"
             icon="move"
             disabled={selectedFiles.length === 0}
             onClick={() => setModal('move')}
+            aria-label="Move"
           />
           <ToolbarButton
             text="Copy"
             icon="copy"
             disabled={selectedFiles.length === 0}
             onClick={() => setModal('copy')}
+            aria-label="Copy"
           />
           <ToolbarButton
             text="Download"
@@ -83,20 +88,23 @@ const Toolbar: React.FC = () => {
             onClick={() => {
               console.log('Toolbar button');
             }}
+            aria-label="Download"
           />
           <ToolbarButton
             text="Upload"
             icon="upload"
-            disabled={true}
+            disabled={false}
             onClick={() => {
               console.log('Toolbar button');
             }}
+            aria-label="Upload"
           />
           <ToolbarButton
             text="Folder"
             icon="add"
-            disabled={!(selectedFiles.length === 0)}
+            disabled={false}
             onClick={() => setModal('createdir')}
+            aria-label="Add"
           />
           <ToolbarButton
             text="Trash"
@@ -105,6 +113,7 @@ const Toolbar: React.FC = () => {
             onClick={() => {
               console.log('Toolbar button');
             }}
+            aria-label="Trash"
           />
           {modal === 'createdir' && (
             <CreateDirModal


### PR DESCRIPTION
## Overview:

Unit tests for toolbar

## Related Github Issues:

- [TUI-213](https://github.com/tapis-project/tapis-ui/issues/213)

## Summary of Changes:

- Unit tests for toolbar
- Always enable Add Folder and Upload regardless of file selection state
- Pass additional props to ToolbarButtons

## Testing Steps:

1. npm run test

## UI Photos:

## Notes:
