### PR TITLE
TUI 231 - Update error decoder with error types

### DIFF
--- a/src/tapis-api/utils/errorDecoder.ts
+++ b/src/tapis-api/utils/errorDecoder.ts
@@ -6,8 +6,8 @@ const errorDecoder = async <T>(func: () => Promise<T>) => {
   } catch (error) {
     // If an exception occurred, try to decode the json response from it and
     // rethrow it
-    if (error.json) {
-      const decoded = await error.json();
+    if ((error as any).json) {
+      const decoded = await (error as any).json();
       throw decoded;
     } else {
       throw error;


### PR DESCRIPTION
## Overview:

Add error type casting to error decoder to avoid unknow type errors with typescript 4.4.X

## Related Github Issues:

- [TUI-231](https://github.com/tapis-project/tapis-ui/issues/231)

## Summary of Changes:

Add type casting to errors

## Testing Steps:

1.

## UI Photos:

## Notes:
