### PR TITLE
Task/TUI 227  nathandf punchlist

### DIFF
--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.module.scss
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.module.scss
@@ -49,3 +49,8 @@
   margin-top: 0.25em;
   box-sizing: border-box;
 }
+
+.remove-file {
+  cursor: pointer;
+  color: red;
+}

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
@@ -98,7 +98,7 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
         toggle();
       }
     },
-    [selectedFiles, toggle]
+    [selectedFiles, toggle, unselect]
   );
 
   const { run, isRunning, isFinished } = useMutations<

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
@@ -196,7 +196,7 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
   return (
     <GenericModal
       toggle={toggle}
-      title="Copy Files"
+      title={`${operation.charAt(0) + operation.slice(1).toLowerCase()} Files`}
       size="xl"
       body={body}
       footer={footer}

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
@@ -29,7 +29,7 @@ export enum FileOpEventStatus {
   loading = 'loading',
   error = 'error',
   success = 'success',
-  progress = 'progress'
+  progress = 'progress',
 }
 
 export type FileOpState = {
@@ -56,12 +56,31 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
 
   const [copyMoveState, dispatch] = useReducer(reducer, {} as FileOpState);
 
-  const { copyAsync, error: copyError, isLoading: moveIsLoading, isSuccess: moveIsSuccess } = useCopy();
-  const { moveAsync, error: moveError, isLoading: copyIsLoading, isSuccess: copyIsSuccess } = useMove();
+  const {
+    copyAsync,
+    error: copyError,
+    isLoading: moveIsLoading,
+    isSuccess: moveIsSuccess,
+  } = useCopy();
+  const {
+    moveAsync,
+    error: moveError,
+    isLoading: copyIsLoading,
+    isSuccess: copyIsSuccess,
+  } = useMove();
 
-  const error = operation === Files.MoveCopyRequestOperationEnum.Move ? moveError : copyError;
-  const isLoading = operation === Files.MoveCopyRequestOperationEnum.Move ? moveIsLoading : copyIsLoading;
-  const isSuccess = operation === Files.MoveCopyRequestOperationEnum.Move ? moveIsSuccess : copyIsSuccess;
+  const error =
+    operation === Files.MoveCopyRequestOperationEnum.Move
+      ? moveError
+      : copyError;
+  const isLoading =
+    operation === Files.MoveCopyRequestOperationEnum.Move
+      ? moveIsLoading
+      : copyIsLoading;
+  const isSuccess =
+    operation === Files.MoveCopyRequestOperationEnum.Move
+      ? moveIsSuccess
+      : copyIsSuccess;
 
   const fn =
     operation === Files.MoveCopyRequestOperationEnum.Copy
@@ -81,10 +100,7 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
     [setDestinationPath]
   );
 
-  const { run } = useMutations<
-    MoveCopyHookParams,
-    Files.FileStringResponse
-  >({
+  const { run } = useMutations<MoveCopyHookParams, Files.FileStringResponse>({
     fn,
     onStart: (item) => {
       dispatch({ key: item.path!, status: FileOpEventStatus.loading });
@@ -186,7 +202,14 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
     <SubmitWrapper
       isLoading={isLoading}
       error={error}
-      success={isSuccess && !error ? "Successfully " + (operation === Files.MoveCopyRequestOperationEnum.Move ? "moved" : "copied") : ''}
+      success={
+        isSuccess && !error
+          ? 'Successfully ' +
+            (operation === Files.MoveCopyRequestOperationEnum.Move
+              ? 'moved'
+              : 'copied')
+          : ''
+      }
       reverse={true}
     >
       <Button
@@ -194,7 +217,9 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
         disabled={
           !destinationPath ||
           destinationPath === path ||
-          isLoading || isSuccess || !!error
+          isLoading ||
+          isSuccess ||
+          !!error
         }
         aria-label="Submit"
         type="submit"

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
@@ -63,7 +63,7 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
     (operation: MoveCopyHookParams, _: Files.FileStringResponse) => {
       dispatch({ path: operation.path, icon: 'approved-reverse' });
     },
-    [dispatch, selectedFiles]
+    [dispatch]
   );
   const onFileCopyMoveError = useCallback(
     (operation: MoveCopyHookParams, error: Error) => {
@@ -98,7 +98,7 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
         toggle();
       }
     },
-    [selectedFiles]
+    [selectedFiles, toggle]
   );
 
   const { run, isRunning, isFinished } = useMutations<

--- a/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/CopyMoveModal/CopyMoveModal.tsx
@@ -95,7 +95,7 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
     (file: Files.FileInfo) => {
       unselect([file]);
       if (selectedFiles.length === 1) {
-        toggle()
+        toggle();
       }
     },
     [selectedFiles]
@@ -188,7 +188,15 @@ const CopyMoveModal: React.FC<CopyMoveModalProps> = ({
     <SubmitWrapper
       isLoading={isRunning}
       error={copyMoveError}
-      success={isFinished && !copyMoveError ? "Successfully " + (operation === Files.MoveCopyRequestOperationEnum.Move ? "moved" : "copied") + " files" : ''}
+      success={
+        isFinished && !copyMoveError
+          ? 'Successfully ' +
+            (operation === Files.MoveCopyRequestOperationEnum.Move
+              ? 'moved'
+              : 'copied') +
+            ' files'
+          : ''
+      }
       reverse={true}
     >
       <Button

--- a/src/tapis-app/Files/_components/Toolbar/Toolbar.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/Toolbar.tsx
@@ -120,7 +120,7 @@ const Toolbar: React.FC = () => {
           <ToolbarButton
             text="Permissions"
             icon="gear"
-            disabled={true/*selectedFiles.length !== 1*/}
+            disabled={true /*selectedFiles.length !== 1*/}
             onClick={() => setModal('permissions')}
           />
           <ToolbarButton

--- a/src/tapis-app/Files/_components/Toolbar/Toolbar.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/Toolbar.tsx
@@ -120,7 +120,7 @@ const Toolbar: React.FC = () => {
           <ToolbarButton
             text="Permissions"
             icon="gear"
-            disabled={selectedFiles.length !== 1}
+            disabled={true/*selectedFiles.length !== 1*/}
             onClick={() => setModal('permissions')}
           />
           <ToolbarButton

--- a/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
@@ -35,7 +35,7 @@ const TransferModal: React.FC<ToolbarModalProps> = ({
       focusManager.setFocused(true);
     }, 5000);
     return () => clearInterval(interval);
-  }, [])
+  }, []);
 
   const onNavigate = useCallback(
     (systemId: string | null, path: string | null) => {

--- a/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
@@ -31,8 +31,7 @@ const TransferModal: React.FC<ToolbarModalProps> = ({
   const [transfer, setTransfer] = useState<Files.TransferTask | null>(null);
   const { selectedFiles } = useFilesSelect();
 
-  const { refetch } = useList({})
-  
+  const { refetch } = useList({});
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { GenericModal, Breadcrumbs } from 'tapis-ui/_common';
 import breadcrumbsFromPathname from 'tapis-ui/_common/Breadcrumbs/breadcrumbsFromPathname';
 import { FileListingTable } from 'tapis-ui/components/files/FileListing/FileListing';
@@ -9,6 +9,7 @@ import { Files } from '@tapis/tapis-typescript';
 import styles from './TransferModal.module.scss';
 import { useFilesSelect } from '../../FilesContext';
 import { Tabs } from 'tapis-app/_components';
+import { focusManager } from 'react-query';
 import {
   TransferListing,
   TransferDetails,
@@ -28,6 +29,13 @@ const TransferModal: React.FC<ToolbarModalProps> = ({
   }>({ systemId, path });
   const [transfer, setTransfer] = useState<Files.TransferTask | null>(null);
   const { selectedFiles } = useFilesSelect();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      focusManager.setFocused(true);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [])
 
   const onNavigate = useCallback(
     (systemId: string | null, path: string | null) => {

--- a/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
@@ -9,7 +9,6 @@ import { Files } from '@tapis/tapis-typescript';
 import styles from './TransferModal.module.scss';
 import { useFilesSelect } from '../../FilesContext';
 import { Tabs } from 'tapis-app/_components';
-import { focusManager } from 'react-query';
 import {
   TransferListing,
   TransferDetails,
@@ -38,7 +37,7 @@ const TransferModal: React.FC<ToolbarModalProps> = ({
       refetch();
     }, 5000);
     return () => clearInterval(interval);
-  }, []);
+  }, [refetch]);
 
   const onNavigate = useCallback(
     (systemId: string | null, path: string | null) => {

--- a/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/TransferModal/TransferModal.tsx
@@ -16,6 +16,7 @@ import {
   TransferCreate,
   TransferCancel,
 } from 'tapis-ui/components/files';
+import { useList } from 'tapis-hooks/files/transfers';
 
 const TransferModal: React.FC<ToolbarModalProps> = ({
   toggle,
@@ -30,9 +31,12 @@ const TransferModal: React.FC<ToolbarModalProps> = ({
   const [transfer, setTransfer] = useState<Files.TransferTask | null>(null);
   const { selectedFiles } = useFilesSelect();
 
+  const { refetch } = useList({})
+  
+
   useEffect(() => {
     const interval = setInterval(() => {
-      focusManager.setFocused(true);
+      refetch();
     }, 5000);
     return () => clearInterval(interval);
   }, []);
@@ -48,7 +52,6 @@ const TransferModal: React.FC<ToolbarModalProps> = ({
 
   const onSelect = useCallback(
     (transfer: Files.TransferTask) => {
-      console.log(transfer);
       setTransfer(transfer);
     },
     [setTransfer]

--- a/src/tapis-app/Files/_components/Toolbar/UploadModal/UploadModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/UploadModal/UploadModal.tsx
@@ -90,7 +90,7 @@ const UploadModal: React.FC<UploadModalProps> = ({
     (file: Files.FileInfo) => {
       setFiles([...files.filter((checkFile) => file.name !== checkFile.name)]);
     },
-    [files, setFiles, toggle]
+    [files, setFiles]
   );
 
   const { uploadAsync, isLoading, error, isSuccess, reset } = useUpload();

--- a/src/tapis-app/Files/_components/Toolbar/UploadModal/UploadModal.tsx
+++ b/src/tapis-app/Files/_components/Toolbar/UploadModal/UploadModal.tsx
@@ -89,9 +89,6 @@ const UploadModal: React.FC<UploadModalProps> = ({
   const removeFile = useCallback(
     (file: Files.FileInfo) => {
       setFiles([...files.filter((checkFile) => file.name !== checkFile.name)]);
-      if (files.length === 1) {
-        toggle();
-      }
     },
     [files, setFiles, toggle]
   );
@@ -218,7 +215,7 @@ const UploadModal: React.FC<UploadModalProps> = ({
         >
           <Button
             color="primary"
-            disabled={isLoading || isSuccess || files.length === 0}
+            disabled={isLoading || isSuccess || !!error || files.length === 0}
             aria-label="Submit"
             onClick={onSubmit}
           >

--- a/src/tapis-ui/components/files/FileListing/FileListing.tsx
+++ b/src/tapis-ui/components/files/FileListing/FileListing.tsx
@@ -197,7 +197,7 @@ const FileSelectHeader: React.FC<FileSelectHeaderProps> = ({
   const [checked, setChecked] = useState(false);
 
   const onClick = useCallback(() => {
-    if (checked) {
+    if (checked && !allSelected) {
       setChecked(false);
       onUnselectAll();
     } else {

--- a/src/tapis-ui/components/files/FileListing/FileListing.tsx
+++ b/src/tapis-ui/components/files/FileListing/FileListing.tsx
@@ -186,13 +186,13 @@ export const FileListingTable: React.FC<FileListingTableProps> = React.memo(
 type FileSelectHeaderProps = {
   onSelectAll: () => void;
   onUnselectAll: () => void;
-  allSelected: boolean
+  allSelected: boolean;
 };
 
 const FileSelectHeader: React.FC<FileSelectHeaderProps> = ({
   onSelectAll,
   onUnselectAll,
-  allSelected
+  allSelected,
 }) => {
   const [checked, setChecked] = useState(false);
 
@@ -285,7 +285,9 @@ const FileListing: React.FC<FileListingProps> = ({
               onUnselectAll={() =>
                 onUnselect && onUnselect(concatenatedResults ?? [])
               }
-              allSelected={Object.values(selectedFileDict).some((value) => value === false)}
+              allSelected={Object.values(selectedFileDict).some(
+                (value) => value === false
+              )}
             />
           ),
           id: 'multiselect',

--- a/src/tapis-ui/components/files/FileListing/FileListing.tsx
+++ b/src/tapis-ui/components/files/FileListing/FileListing.tsx
@@ -186,13 +186,17 @@ export const FileListingTable: React.FC<FileListingTableProps> = React.memo(
 type FileSelectHeaderProps = {
   onSelectAll: () => void;
   onUnselectAll: () => void;
+  selectedFiles: Array<Files.FileInfo>
 };
 
 const FileSelectHeader: React.FC<FileSelectHeaderProps> = ({
   onSelectAll,
   onUnselectAll,
+  selectedFiles,
 }) => {
   const [checked, setChecked] = useState(false);
+  const handleChecked = () => checked && selectedFiles.length > 0;
+
   const onClick = useCallback(() => {
     if (checked) {
       setChecked(false);
@@ -208,7 +212,7 @@ const FileSelectHeader: React.FC<FileSelectHeaderProps> = ({
       onClick={onClick}
       data-testid="select-all"
     >
-      <FileListingCheckboxCell selected={checked} />
+      <FileListingCheckboxCell selected={handleChecked()} />
     </span>
   );
 };
@@ -281,6 +285,7 @@ const FileListing: React.FC<FileListingProps> = ({
               onUnselectAll={() =>
                 onUnselect && onUnselect(concatenatedResults ?? [])
               }
+              selectedFiles={selectedFiles}
             />
           ),
           id: 'multiselect',

--- a/src/tapis-ui/components/files/FileListing/FileListing.tsx
+++ b/src/tapis-ui/components/files/FileListing/FileListing.tsx
@@ -186,16 +186,20 @@ export const FileListingTable: React.FC<FileListingTableProps> = React.memo(
 type FileSelectHeaderProps = {
   onSelectAll: () => void;
   onUnselectAll: () => void;
-  allSelected: boolean;
+  selectedFileDict: SelectFileDictType;
 };
+
+type SelectFileDictType = { [path: string]: boolean };
 
 const FileSelectHeader: React.FC<FileSelectHeaderProps> = ({
   onSelectAll,
   onUnselectAll,
-  allSelected,
+  selectedFileDict,
 }) => {
   const [checked, setChecked] = useState(false);
-
+  const allSelected = Object.values(selectedFileDict).some(
+    (value) => value === false
+  );
   const onClick = useCallback(() => {
     if (checked && !allSelected) {
       setChecked(false);
@@ -262,9 +266,9 @@ const FileListing: React.FC<FileListingProps> = ({
     [concatenatedResults]
   );
 
-  const selectedFileDict: { [path: string]: boolean } = React.useMemo(() => {
-    const result: { [path: string]: boolean } = {};
-    const selectedDict: { [path: string]: boolean } = {};
+  const selectedFileDict: SelectFileDictType = React.useMemo(() => {
+    const result: SelectFileDictType = {};
+    const selectedDict: SelectFileDictType = {};
     selectedFiles.forEach((file) => {
       selectedDict[file.path ?? ''] = true;
     });
@@ -285,9 +289,7 @@ const FileListing: React.FC<FileListingProps> = ({
               onUnselectAll={() =>
                 onUnselect && onUnselect(concatenatedResults ?? [])
               }
-              allSelected={Object.values(selectedFileDict).some(
-                (value) => value === false
-              )}
+              selectedFileDict={selectedFileDict}
             />
           ),
           id: 'multiselect',

--- a/src/tapis-ui/components/files/FileListing/FileListing.tsx
+++ b/src/tapis-ui/components/files/FileListing/FileListing.tsx
@@ -186,16 +186,15 @@ export const FileListingTable: React.FC<FileListingTableProps> = React.memo(
 type FileSelectHeaderProps = {
   onSelectAll: () => void;
   onUnselectAll: () => void;
-  selectedFiles: Array<Files.FileInfo>
+  allSelected: boolean
 };
 
 const FileSelectHeader: React.FC<FileSelectHeaderProps> = ({
   onSelectAll,
   onUnselectAll,
-  selectedFiles,
+  allSelected
 }) => {
   const [checked, setChecked] = useState(false);
-  const handleChecked = () => checked && selectedFiles.length > 0;
 
   const onClick = useCallback(() => {
     if (checked) {
@@ -205,14 +204,15 @@ const FileSelectHeader: React.FC<FileSelectHeaderProps> = ({
       setChecked(true);
       onSelectAll();
     }
-  }, [checked, setChecked, onSelectAll, onUnselectAll]);
+  }, [checked, setChecked, onSelectAll, onUnselectAll, allSelected]);
+
   return (
     <span
       className={styles['select-all']}
       onClick={onClick}
       data-testid="select-all"
     >
-      <FileListingCheckboxCell selected={handleChecked()} />
+      <FileListingCheckboxCell selected={checked && !allSelected} />
     </span>
   );
 };
@@ -285,7 +285,7 @@ const FileListing: React.FC<FileListingProps> = ({
               onUnselectAll={() =>
                 onUnselect && onUnselect(concatenatedResults ?? [])
               }
-              selectedFiles={selectedFiles}
+              allSelected={Object.values(selectedFileDict).some((value) => value === false)}
             />
           ),
           id: 'multiselect',


### PR DESCRIPTION
## Overview:
Punch-list items to finish up Files milestone

## Related Github Issues:
- [TUI-227](https://github.com/tapis-project/tapis-ui/issues/227)

## Summary of Changes:
- master select unchecks when there are no selected files
- file transfers listings update with interval timer
- disabled Permissions modal
- selected files state persist after move/copy operation
- implemented file ops reducer pattern from uploads
- dynamic naming of move copy modal

## Testing Steps:
1. Trigger move/copy modal to see the headers, buttons, etc. dynamically set based on file operation
2. Try to trigger permissions modal (you can't; disabled)
3. Use master select to select all files, then click the checkbox of one or more files. Master select will uncheck.

