### PR TITLE
task/TUI-282 -- initial values should be based on current job value

### DIFF
--- a/src/tapis-ui/components/jobs/JobLauncher/steps/FileInputs.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/FileInputs.tsx
@@ -17,7 +17,6 @@ import { FormikJobStepWrapper } from '../components';
 import { FormikInput, FormikCheck } from 'tapis-ui/_common/FieldWrapperFormik';
 import { v4 as uuidv4 } from 'uuid';
 import * as Yup from 'yup';
-import { generateRequiredFileInputsFromApp } from 'tapis-api/utils/jobFileInputs';
 
 type FileInputFieldProps = {
   item: Jobs.JobFileInput;
@@ -302,7 +301,7 @@ const JobInputs: React.FC<{ arrayHelpers: FieldArrayRenderProps }> = ({
 };
 
 export const FileInputs: React.FC = () => {
-  const { app } = useJobLauncher();
+  const { job } = useJobLauncher();
 
   const validationSchema = Yup.object().shape({
     fileInputs: Yup.array().of(
@@ -317,10 +316,9 @@ export const FileInputs: React.FC = () => {
 
   const initialValues = useMemo(
     () => ({
-      fileInputs: generateRequiredFileInputsFromApp(app),
+      fileInputs: job.fileInputs,
     }),
-    /* eslint-disable-next-line */
-    [app.id, app.version]
+    [job]
   );
 
   return (


### PR DESCRIPTION
## Overview:

JobFileInputs step Formik initialValue should not generate new values, but instead should use what is currently in the useJobLauncher hook

## Related Github Issues:

- [TUI-282](https://github.com/tapis-project/tapis-ui/issues/282)

## Summary of Changes:

## Testing Steps:

1. Test FileInputs steps (adding, removing, changing values, navigating past it and then returning to it)

## UI Photos:

## Notes:
