### PR TITLE
task/TUI-311--job name

### DIFF
--- a/src/tapis-api/utils/jobDefaults.ts
+++ b/src/tapis-api/utils/jobDefaults.ts
@@ -17,7 +17,7 @@ const generateJobDefaults = ({
     (system) => system.id === app.jobAttributes?.execSystemId
   )?.batchDefaultLogicalQueue;
   const defaultValues: Partial<Jobs.ReqSubmitJob> = {
-    name: `${app.id}-${app.version}-${new Date().toISOString().slice(0, -5)}`,
+    name: `${app.id}-${app.version}`,
     description: app.description,
     appId: app.id,
     appVersion: app.version,

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/JobStart.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/JobStart.tsx
@@ -58,7 +58,7 @@ const generateInitialValues = ({
 });
 
 const validationSchema = Yup.object({
-  name: Yup.string().required(),
+  name: Yup.string().required().min(1).max(64),
   description: Yup.string(),
 });
 


### PR DESCRIPTION
## Overview:

Shortens default job name and limits name to 64 characters

## Related Github Issues:

- [TUI-311](https://github.com/tapis-project/tapis-ui/issues/311

## Summary of Changes:

- generateDefaultValues from app no longer includes current date/time
- JobStart step requires that job names be at most 64 characters

## Testing Steps:

1.

## UI Photos:

## Notes:

- This PR will likely be reverted after requested changes to the TAPIS API for longer names is implemented