### PR TITLE
task/TUI-314 -- filter exec systems when selecting batch jobType

### DIFF
--- a/src/tapis-api/utils/jobDefaults.ts
+++ b/src/tapis-api/utils/jobDefaults.ts
@@ -13,9 +13,7 @@ const generateJobDefaults = ({
   if (!app) {
     return {};
   }
-  const systemDefaultQueue = systems.find(
-    (system) => system.id === app.jobAttributes?.execSystemId
-  )?.batchDefaultLogicalQueue;
+
   const defaultValues: Partial<Jobs.ReqSubmitJob> = {
     name: `${app.id}-${app.version}`,
     description: app.description,
@@ -32,9 +30,6 @@ const generateJobDefaults = ({
     isMpi: app.jobAttributes?.isMpi,
     mpiCmd: app.jobAttributes?.mpiCmd,
     cmdPrefix: app.jobAttributes?.cmdPrefix,
-    execSystemId: app.jobAttributes?.execSystemId,
-    execSystemLogicalQueue:
-      app.jobAttributes?.execSystemLogicalQueue ?? systemDefaultQueue,
     fileInputs: generateRequiredFileInputsFromApp(app),
     fileInputArrays: generateRequiredFileInputArraysFromApp(app),
     parameterSet: {

--- a/src/tapis-api/utils/jobExecSystem.test.ts
+++ b/src/tapis-api/utils/jobExecSystem.test.ts
@@ -1,0 +1,118 @@
+import { Apps, Systems } from '@tapis/tapis-typescript';
+import '@testing-library/jest-dom/extend-expect';
+import { tapisApp } from 'fixtures/apps.fixtures';
+import { tapisSystem } from 'fixtures/systems.fixtures';
+import {
+  computeDefaultQueue,
+  computeDefaultSystem,
+  validateExecSystem,
+  ValidateExecSystemResult,
+} from './jobExecSystem';
+
+describe('Job Exec System utils', () => {
+  it('determines default system', () => {
+    expect(computeDefaultSystem(tapisApp)).toEqual({
+      source: 'app',
+      systemId: 'testuser2.execution',
+    });
+  });
+  it('determines the default logical queue from an app', () => {
+    expect(computeDefaultQueue({}, tapisApp, [tapisSystem])).toEqual({
+      source: 'app',
+      queue: 'tapisNormal',
+    });
+  });
+  it('determines the default logical queue from the default system specified by the app', () => {
+    const tapisAppNoQueue = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
+    tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
+    expect(computeDefaultQueue({}, tapisAppNoQueue, [tapisSystem])).toEqual({
+      source: 'app system',
+      queue: 'tapisNormal',
+    });
+  });
+  it('determines the default logical queue from a system default, where the system is selected by the job', () => {
+    const tapisAppNoQueue = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
+    tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
+    expect(
+      computeDefaultQueue(
+        { execSystemId: 'testuser2.execution' },
+        tapisAppNoQueue,
+        [tapisSystem]
+      )
+    ).toEqual({
+      source: 'system',
+      queue: 'tapisNormal',
+    });
+  });
+  it('determines that there is no computed queue if a system does not exist', () => {
+    const tapisAppNoQueue = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
+    tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
+    expect(computeDefaultQueue({}, tapisAppNoQueue, [])).toEqual({
+      source: undefined,
+      queue: undefined,
+    });
+  });
+  it('detects a valid job request that satisfies exec system options', () => {
+    expect(validateExecSystem({}, tapisApp, [tapisSystem])).toBe(
+      ValidateExecSystemResult.Complete
+    );
+  });
+  it('skips queue validation if a complete job request will be a FORK job', () => {
+    expect(
+      validateExecSystem({ jobType: Apps.JobTypeEnum.Fork }, tapisApp, [
+        tapisSystem,
+      ])
+    ).toBe(ValidateExecSystemResult.Complete);
+  });
+  it('detects an invalid job request if the specified exec system is missing', () => {
+    expect(validateExecSystem({}, tapisApp, [])).toBe(
+      ValidateExecSystemResult.ErrorExecSystemNotFound
+    );
+  });
+  it('detects an invalid job request if an exec system is not specified', () => {
+    const tapisAppNoSystem = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
+    tapisAppNoSystem.jobAttributes!.execSystemId = undefined;
+    expect(validateExecSystem({}, tapisAppNoSystem, [])).toBe(
+      ValidateExecSystemResult.ErrorNoExecSystem
+    );
+  });
+  it('detects an invalid job request if a queue cannot be found', () => {
+    const tapisAppNoQueue = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
+    tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
+    const tapisSystemNoDefaultQueue = JSON.parse(
+      JSON.stringify(tapisSystem)
+    ) as Systems.TapisSystem;
+    tapisSystemNoDefaultQueue.batchDefaultLogicalQueue = undefined;
+    expect(
+      validateExecSystem({}, tapisAppNoQueue, [tapisSystemNoDefaultQueue])
+    ).toBe(ValidateExecSystemResult.ErrorNoQueue);
+  });
+  it('detects an invalid job request if the job is a batch job but the selected system has no queues', () => {
+    const tapisSystemNoQueue = JSON.parse(
+      JSON.stringify(tapisSystem)
+    ) as Systems.TapisSystem;
+    tapisSystemNoQueue.batchLogicalQueues = [];
+    expect(
+      validateExecSystem({ jobType: Apps.JobTypeEnum.Batch }, tapisApp, [
+        tapisSystemNoQueue,
+      ])
+    ).toBe(ValidateExecSystemResult.ErrorExecSystemNoQueues);
+  });
+  it('detects an invalid job request if the job specifies a queue that the exec system does not have', () => {
+    expect(
+      validateExecSystem({ execSystemLogicalQueue: 'badQueue' }, tapisApp, [
+        tapisSystem,
+      ])
+    ).toBe(ValidateExecSystemResult.ErrorQueueNotFound);
+  });
+});

--- a/src/tapis-api/utils/jobExecSystem.ts
+++ b/src/tapis-api/utils/jobExecSystem.ts
@@ -1,0 +1,207 @@
+import { Apps, Jobs, Systems } from '@tapis/tapis-typescript';
+
+type DefaultSystem = {
+  source?: 'app';
+  systemId?: string;
+};
+
+/**
+ * Computes the default execution system ID that will be used
+ *
+ * @param app
+ * @returns
+ */
+export const computeDefaultSystem = (app: Apps.TapisApp): DefaultSystem => {
+  if (app.jobAttributes?.execSystemId) {
+    return {
+      source: 'app',
+      systemId: app.jobAttributes?.execSystemId,
+    };
+  }
+  return {
+    source: undefined,
+    systemId: undefined,
+  };
+};
+
+type DefaultQueue = {
+  source?: 'app' | 'system' | 'app system';
+  queue?: string;
+};
+
+/**
+ * Computes the logical queue that will be used, if the job does not
+ * specify one
+ *
+ * @param job
+ * @param app
+ * @param systems
+ * @returns
+ */
+export const computeDefaultQueue = (
+  job: Partial<Jobs.ReqSubmitJob>,
+  app: Apps.TapisApp,
+  systems: Array<Systems.TapisSystem>
+): DefaultQueue => {
+  // If the app specifies the logical queue, use that
+  if (app.jobAttributes?.execSystemLogicalQueue) {
+    return {
+      source: 'app',
+      queue: app.jobAttributes?.execSystemLogicalQueue,
+    };
+  }
+
+  // If the job specifies a system, look for its default logical queue
+  if (job.execSystemId) {
+    const selectedSystem = systems.find(
+      (system) => system.id === job.execSystemId
+    );
+    if (selectedSystem?.batchDefaultLogicalQueue) {
+      return {
+        source: 'system',
+        queue: selectedSystem.batchDefaultLogicalQueue,
+      };
+    }
+  }
+
+  // If the app specifies a system, look for its default logical queue
+  if (app.jobAttributes?.execSystemId) {
+    const appSystem = systems.find(
+      (system) => system.id === app.jobAttributes?.execSystemId
+    );
+    if (appSystem?.batchDefaultLogicalQueue) {
+      return {
+        source: 'app system',
+        queue: appSystem.batchDefaultLogicalQueue,
+      };
+    }
+  }
+
+  // Return a result that has no computed default logical queue
+  return {
+    source: undefined,
+    queue: undefined,
+  };
+};
+
+type DefaultJobType = {
+  source: 'app' | 'app system' | 'system' | 'tapis';
+  jobType: Apps.JobTypeEnum;
+};
+
+/**
+ * Determines the default jobType if one is not specified in the jobType field in a job
+ * using the algorithm specified at:
+ *
+ * https://tapis.readthedocs.io/en/latest/technical/jobs.html#job-type
+ *
+ * @param job
+ * @param app
+ * @param systems
+ * @returns
+ */
+export const computeDefaultJobType = (
+  job: Partial<Jobs.ReqSubmitJob>,
+  app: Apps.TapisApp,
+  systems: Array<Systems.TapisSystem>
+): DefaultJobType => {
+  if (app.jobType) {
+    return {
+      source: 'app',
+      jobType: app.jobType!,
+    };
+  }
+  if (job?.execSystemId) {
+    const selectedSystem = systems.find(
+      (system) => system.id === job.execSystemId
+    );
+    if (selectedSystem?.canRunBatch) {
+      return {
+        source: 'system',
+        jobType: Apps.JobTypeEnum.Batch,
+      };
+    }
+  }
+  if (app.jobAttributes?.execSystemId) {
+    const appSystem = systems.find(
+      (system) => system.id === app.jobAttributes?.execSystemId
+    );
+    if (appSystem?.canRunBatch) {
+      return {
+        source: 'app system',
+        jobType: Apps.JobTypeEnum.Batch,
+      };
+    }
+  }
+  return {
+    source: 'tapis',
+    jobType: Apps.JobTypeEnum.Fork,
+  };
+};
+
+export enum ValidateExecSystemResult {
+  Complete = 'COMPLETE',
+  ErrorNoExecSystem = 'ERROR_NO_EXEC_SYSTEM',
+  ErrorExecSystemNotFound = 'ERROR_EXEC_SYSTEM_NOT_FOUND',
+  ErrorExecSystemNoQueues = 'ERROR_EXEC_SYSTEM_NO_QUEUES',
+  ErrorNoQueue = 'ERROR_NO_QUEUE',
+  ErrorQueueNotFound = 'ERROR_QUEUE_NOT_FOUND',
+}
+
+export const validateExecSystem = (
+  job: Partial<Jobs.ReqSubmitJob>,
+  app: Apps.TapisApp,
+  systems: Array<Systems.TapisSystem>
+): ValidateExecSystemResult => {
+  const defaultSystem = computeDefaultSystem(app);
+
+  // Check that an exec system can be computed
+  if (!job.execSystemId && !defaultSystem?.systemId) {
+    return ValidateExecSystemResult.ErrorNoExecSystem;
+  }
+
+  const computedSystem = systems.find(
+    (system) => system.id === (job.execSystemId ?? defaultSystem?.systemId)
+  );
+  if (!computedSystem) {
+    return ValidateExecSystemResult.ErrorExecSystemNotFound;
+  }
+
+  // If the job will be a FORK job, skip queue validation
+  const computedJobType = computeDefaultJobType(job, app, systems);
+  if (
+    job.jobType !== Apps.JobTypeEnum.Batch &&
+    computedJobType.jobType === Apps.JobTypeEnum.Fork
+  ) {
+    return ValidateExecSystemResult.Complete;
+  }
+
+  // If the job will be a BATCH job, make sure that the selected execution system
+  // has queues
+  if (!computedSystem.batchLogicalQueues?.length) {
+    return ValidateExecSystemResult.ErrorExecSystemNoQueues;
+  }
+
+  const defaultQueue = computeDefaultQueue(job, app, systems);
+
+  // If the job type will be a BATCH job, ensure that a queue is specified
+  // If no queue exists, there must be a fallback to the app or system default
+  if (!job.execSystemLogicalQueue && !defaultQueue.queue) {
+    return ValidateExecSystemResult.ErrorNoQueue;
+  }
+
+  // Check to see that the logical queue selected exists on the selected system
+  const selectedSystem = systems.find(
+    (system) => system.id === (job.execSystemId ?? defaultSystem?.systemId)
+  );
+  if (
+    !selectedSystem?.batchLogicalQueues?.some(
+      (queue) =>
+        queue.name === (job.execSystemLogicalQueue ?? defaultQueue.queue)
+    )
+  ) {
+    return ValidateExecSystemResult.ErrorQueueNotFound;
+  }
+
+  return ValidateExecSystemResult.Complete;
+};

--- a/src/tapis-api/utils/jobRequiredFields.ts
+++ b/src/tapis-api/utils/jobRequiredFields.ts
@@ -1,5 +1,5 @@
 import { Jobs } from '@tapis/tapis-typescript';
 
 export const jobRequiredFieldsComplete = (job: Partial<Jobs.ReqSubmitJob>) => {
-  return !!job.name && !!job.appId && !!job.appVersion && !!job.execSystemId;
+  return !!job.name && !!job.appId && !!job.appVersion;
 };

--- a/src/tapis-ui/_common/FieldWrapperFormik/fields/FormikSelect.tsx
+++ b/src/tapis-ui/_common/FieldWrapperFormik/fields/FormikSelect.tsx
@@ -1,8 +1,9 @@
 import { ChangeEvent } from 'react';
 import FieldWrapper from '../FieldWrapperFormik';
 import { Input } from 'reactstrap';
-import { FieldInputProps } from 'formik';
+import { FieldInputProps, useFormikContext } from 'formik';
 import { FormikInputProps } from '.';
+import { setFieldValue } from './formikPatch';
 
 const FormikSelect: React.FC<React.PropsWithChildren<FormikInputProps>> = ({
   name,
@@ -11,32 +12,40 @@ const FormikSelect: React.FC<React.PropsWithChildren<FormikInputProps>> = ({
   description,
   children,
   ...props
-}: FormikInputProps) => (
-  <FieldWrapper
-    name={name}
-    label={label}
-    required={required}
-    description={description}
-    as={(formikProps: FieldInputProps<any>) => {
-      const { onChange: formikOnChange, ...otherFormikProps } = formikProps;
-      const { onChange: passedOnChange, ...otherProps } = props;
-      const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-        passedOnChange && passedOnChange(event);
-        formikOnChange && formikOnChange(event);
-      };
-      return (
-        <Input
-          bsSize="sm"
-          type="select"
-          onChange={onChange}
-          {...otherProps}
-          {...otherFormikProps}
-        >
-          {children}
-        </Input>
-      );
-    }}
-  />
-);
+}: FormikInputProps) => {
+  const formikContext = useFormikContext();
+  return (
+    <FieldWrapper
+      name={name}
+      label={label}
+      required={required}
+      description={description}
+      as={(formikProps: FieldInputProps<any>) => {
+        const { onChange: formikOnChange, ...otherFormikProps } = formikProps;
+        const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+          // Use patched formik setFieldValue
+          // An option with no children and value set to undefined will preduce an empty string as the target value
+          // ex: <option value={undefined} label="Please select a value" />
+          setFieldValue(
+            formikContext,
+            name,
+            event.target.value === '' ? undefined : event.target.value
+          );
+        };
+        return (
+          <Input
+            bsSize="sm"
+            type="select"
+            onChange={onChange}
+            {...props}
+            {...otherFormikProps}
+          >
+            {children}
+          </Input>
+        );
+      }}
+    />
+  );
+};
 
 export default FormikSelect;

--- a/src/tapis-ui/_common/FieldWrapperFormik/fields/formikPatch.ts
+++ b/src/tapis-ui/_common/FieldWrapperFormik/fields/formikPatch.ts
@@ -1,0 +1,82 @@
+import { FormikContextType, getIn, isObject, isInteger } from 'formik';
+import _ from 'lodash';
+
+/**
+ * Adaptation of setFieldValue wrapper from https://github.com/jaredpalmer/formik/issues/2332#issuecomment-819571154
+ *
+ * There is a bug in the setIn function of Formik that deletes form keys that have undefined values rather than
+ * setting the field value to undefined. This is inconsistent with other types of Formik behavior, such as
+ * empty text Inputs resulting in form keys with undefined values
+ *
+ * @param formikContext
+ * @param field
+ * @param value
+ * @param shouldValidate
+ */
+export function setFieldValue(
+  formikContext: FormikContextType<unknown>,
+  field: string,
+  value: any,
+  shouldValidate?: boolean
+): void {
+  const { setValues, validateForm, validateOnChange, setFieldValue, values } =
+    formikContext;
+  // Override default behavior by forcing undefined to be set on the state
+  if (value === undefined) {
+    const setInValues = setIn(values, field, undefined);
+    setValues(setInValues);
+
+    const willValidate =
+      shouldValidate === undefined ? validateOnChange : shouldValidate;
+    if (willValidate) {
+      validateForm(setInValues);
+    }
+  } else {
+    // Use default behavior for normal values
+    setFieldValue(field, value, shouldValidate);
+  }
+}
+
+/**
+ * A copy of Formik's setIn function, except it assigns undefined instead of deleting the property if the value
+ * being set is undefined.
+ * https://github.com/jaredpalmer/formik/issues/2332
+ */
+function setIn(obj: any, path: string, value: any): any {
+  const res: any = _.clone(obj); // This keeps inheritance when obj is a class
+  let resVal: any = res;
+  let i = 0;
+  const pathArray = _.toPath(path);
+
+  for (; i < pathArray.length - 1; i++) {
+    const currentPath: string = pathArray[i];
+    const currentObj: any = getIn(obj, pathArray.slice(0, i + 1));
+
+    if (currentObj && (isObject(currentObj) || Array.isArray(currentObj))) {
+      resVal = resVal[currentPath] = _.clone(currentObj);
+    } else {
+      const nextPath: string = pathArray[i + 1];
+      resVal = resVal[currentPath] =
+        isInteger(nextPath) && Number(nextPath) >= 0 ? [] : {};
+    }
+  }
+
+  // Return original object if new value is the same as current
+  if ((i === 0 ? obj : resVal)[pathArray[i]] === value) {
+    return obj;
+  }
+
+  if (value === undefined) {
+    resVal[pathArray[i]] = undefined;
+  } else {
+    resVal[pathArray[i]] = value;
+  }
+
+  // If the path array has a single element, the loop did not run.
+  // Deleting on `resVal` had no effect in this scenario, so we delete on the result instead.
+  if (i === 0 && value === undefined) {
+    res[pathArray[i]] = undefined;
+  }
+
+  return res;
+}

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
@@ -21,7 +21,7 @@ const JobLauncherWizardRender: React.FC = () => {
 
   const formSubmit = useCallback(
     (value: Partial<Jobs.ReqSubmitJob>) => {
-      console.log("Values", value);
+      console.log('Values', value);
       if (value.jobType === Apps.JobTypeEnum.Fork) {
         value.execSystemLogicalQueue = undefined;
       }

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
@@ -21,6 +21,7 @@ const JobLauncherWizardRender: React.FC = () => {
 
   const formSubmit = useCallback(
     (value: Partial<Jobs.ReqSubmitJob>) => {
+      console.log("Values", value);
       if (value.jobType === Apps.JobTypeEnum.Fork) {
         value.execSystemLogicalQueue = undefined;
       }

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { WizardStep } from 'tapis-ui/_wrappers/Wizard';
 import { QueryWrapper, Wizard } from 'tapis-ui/_wrappers';
-import { Jobs } from '@tapis/tapis-typescript';
+import { Apps, Jobs } from '@tapis/tapis-typescript';
 import { useDetail as useAppDetail } from 'tapis-hooks/apps';
 import generateJobDefaults from 'tapis-api/utils/jobDefaults';
 import {
@@ -21,6 +21,9 @@ const JobLauncherWizardRender: React.FC = () => {
 
   const formSubmit = useCallback(
     (value: Partial<Jobs.ReqSubmitJob>) => {
+      if (value.jobType === Apps.JobTypeEnum.Fork) {
+        value.execSystemLogicalQueue = undefined;
+      }
       if (value.isMpi) {
         value.cmdPrefix = undefined;
       } else {

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.test.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.test.tsx
@@ -1,34 +1,60 @@
 import '@testing-library/jest-dom/extend-expect';
-import { tapisSystem } from 'fixtures/systems.fixtures';
+import renderComponent from 'utils/testing';
 import { tapisApp } from 'fixtures/apps.fixtures';
-import { getLogicalQueue } from './ExecOptions';
+import { tapisSystem } from 'fixtures/systems.fixtures';
+import useJobLauncher from 'tapis-ui/components/jobs/JobLauncher/components/useJobLauncher';
+import ExecOptionsStep from './ExecOptions';
+import { JobLauncherWizardRender } from '../JobLauncherWizard';
+import { act } from '@testing-library/react';
+import { Systems } from '@tapis/tapis-typescript';
 
-describe('ExecSystem job launcher step', () => {
-  it('Finds the default logical queue for an app', async () => {
-    // If the app default logical queue is available in the selected system, then use that
-    expect(
-      getLogicalQueue(tapisApp, [tapisSystem], 'testuser2.execution')
-    ).toEqual('tapisNormal');
+jest.mock('tapis-ui/components/jobs/JobLauncher/components/useJobLauncher');
 
-    // If the app default logical queue is available in the selected system even if it's a different system, use that
-    const alternateSystem = JSON.parse(JSON.stringify(tapisSystem));
-    alternateSystem.id = 'alternateSystem';
-    expect(
-      getLogicalQueue(tapisApp, [alternateSystem], 'alternateSystem')
-    ).toEqual('tapisNormal');
-
-    // If the app default logical queue is not available in the selected system, use that system's default queue
-    alternateSystem.batchDefaultLogicalQueue = 'alternateQueue';
-    alternateSystem.batchLogicalQueues[0].name = 'alternateQueue';
-    expect(
-      getLogicalQueue(tapisApp, [alternateSystem], 'alternateSystem')
-    ).toEqual('alternateQueue');
-
-    // If the app default logical queue is not available in the selected system and there is no fallback, then
-    // logical queue result will be undefined
-    alternateSystem.batchDefaultLogicalQueue = undefined;
-    expect(
-      getLogicalQueue(tapisApp, [alternateSystem], 'alternateSystem')
-    ).not.toBeDefined();
+describe('ExecOptions step', () => {
+  it('Shows default systems', async () => {
+    (useJobLauncher as jest.Mock).mockReturnValue({
+      job: {},
+      app: tapisApp,
+      systems: [tapisSystem],
+    });
+    const { getAllByTestId } = renderComponent(
+      <JobLauncherWizardRender jobSteps={[ExecOptionsStep]} />
+    );
+    await act(async () => {});
+    const execSystemId = getAllByTestId('execSystemId')[0];
+    expect(execSystemId).toHaveValue('');
+  });
+  it('Shows queue options if the job is a batch job', async () => {
+    (useJobLauncher as jest.Mock).mockReturnValue({
+      job: {},
+      app: tapisApp,
+      systems: [tapisSystem],
+    });
+    const { getAllByTestId } = renderComponent(
+      <JobLauncherWizardRender jobSteps={[ExecOptionsStep]} />
+    );
+    await act(async () => {});
+    const execSystemLogicalQueue = getAllByTestId('execSystemLogicalQueue')[0];
+    expect(execSystemLogicalQueue).toBeDefined();
+    expect(execSystemLogicalQueue).toHaveValue('');
+  });
+  it('Does not show systems that are not capable of batch jobs', async () => {
+    const tapisSystemNoQueues = JSON.parse(
+      JSON.stringify(tapisSystem)
+    ) as Systems.TapisSystem;
+    tapisSystemNoQueues.batchLogicalQueues = [];
+    tapisSystemNoQueues.id = 'noqueues.execution';
+    (useJobLauncher as jest.Mock).mockReturnValue({
+      job: {},
+      app: tapisApp,
+      systems: [tapisSystem, tapisSystemNoQueues],
+    });
+    const { getAllByTestId } = renderComponent(
+      <JobLauncherWizardRender jobSteps={[ExecOptionsStep]} />
+    );
+    await act(async () => {});
+    const execSystems = getAllByTestId(/execSystemId-/);
+    expect(execSystems.length).toEqual(1);
+    expect(execSystems[0]).toHaveProperty('label', 'testuser2.execution');
   });
 });

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -73,24 +73,24 @@ const SystemSelector: React.FC = () => {
     [values]
   );
 
-  const selectedSystemDefaultLogicalQueue = useMemo(
-    () => {
-      const computedSystem = selectedSystem ?? app.jobAttributes?.execSystemId;
-      if (!computedSystem) {
-        return undefined;
-      }
-      return systems.find(system => system.id === computedSystem)?.batchDefaultLogicalQueue;
-    },
-    [ selectedSystem, systems, app ]
-  )
+  const selectedSystemDefaultLogicalQueue = useMemo(() => {
+    const computedSystem = selectedSystem ?? app.jobAttributes?.execSystemId;
+    if (!computedSystem) {
+      return undefined;
+    }
+    return systems.find((system) => system.id === computedSystem)
+      ?.batchDefaultLogicalQueue;
+  }, [selectedSystem, systems, app]);
 
   useEffect(() => {
     const validSystems = isBatch
       ? systems.filter((system) => !!system.batchLogicalQueues?.length)
       : systems;
     setSelectableSystems(validSystems);
-    if (!validSystems.some(system => system.id === selectedSystem)) {
-      setFieldValue('execSystemId', undefined);
+    if (!validSystems.some((system) => system.id === selectedSystem)) {
+      // If current system is invalid (like a system with no logical queues for a batch job)
+      // then use the application default
+      setFieldValue('execSystemId', app.jobAttributes?.execSystemId);
     }
     if (!isBatch) {
       setFieldValue('execSystemLogicalQueue', undefined);
@@ -118,11 +118,9 @@ const SystemSelector: React.FC = () => {
         name="execSystemId"
         description="The execution system for this job"
         label="Execution System"
-        required={false}
+        required={true}
       >
-        <option value={undefined}>
-          {app.jobAttributes?.execSystemId ? `App default (${app.jobAttributes?.execSystemId})`: `Please select a system`}
-        </option>
+        <option value={undefined} />
         {selectableSystems.map((system) => (
           <option value={system.id} key={`execsystem-select-${system.id}`}>
             {system.id}
@@ -146,13 +144,11 @@ const SystemSelector: React.FC = () => {
           required={false}
         >
           <option value={undefined}>
-            {
-              app.jobAttributes?.execSystemLogicalQueue
-                ? `App default (${app.jobAttributes?.execSystemLogicalQueue})`
-                : selectedSystemDefaultLogicalQueue
-                  ? `System default (${selectedSystemDefaultLogicalQueue})`
-                  : 'Please select a logical queue'
-            }
+            {app.jobAttributes?.execSystemLogicalQueue
+              ? `App default (${app.jobAttributes?.execSystemLogicalQueue})`
+              : selectedSystemDefaultLogicalQueue
+              ? `System default (${selectedSystemDefaultLogicalQueue})`
+              : 'Please select a logical queue'}
           </option>
           {queues.map((queue) => (
             <option value={queue.name} key={`queue-select-${queue.name}`}>

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -60,6 +60,8 @@ const SystemSelector: React.FC = () => {
     getLogicalQueues(getSystem(systems, job.execSystemId))
   );
 
+  const [selectableSystems, setSelectableSystems] = useState<Array<Systems.TapisSystem>>(systems);
+
   const selectedSystem = useMemo(
     () => (values as Jobs.ReqSubmitJob)?.execSystemId,
     [values]
@@ -72,11 +74,15 @@ const SystemSelector: React.FC = () => {
 
   useEffect(
     () => {
+      const validSystems = isBatch
+        ? systems.filter(system => !!system.batchLogicalQueues?.length)
+        : systems;
       const logicalQueue = isBatch
-        ? getLogicalQueue(app, systems, selectedSystem)
+        ? getLogicalQueue(app, validSystems, selectedSystem)
         : undefined;
-      const system = getSystem(systems, selectedSystem);
+      const system = getSystem(validSystems, selectedSystem);
       const queues = getLogicalQueues(system);
+      setSelectableSystems(validSystems);
       setQueues(queues);
       setFieldValue('execSystemLogicalQueue', logicalQueue);
       add({
@@ -97,7 +103,7 @@ const SystemSelector: React.FC = () => {
         required={true}
       >
         <option value={undefined} />
-        {systems.map((system) => (
+        {selectableSystems.map((system) => (
           <option value={system.id} key={`execsystem-select-${system.id}`}>
             {system.id}
           </option>

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -54,7 +54,7 @@ export const getLogicalQueue = (
 
 const SystemSelector: React.FC = () => {
   const { setFieldValue, values } = useFormikContext();
-  const { job, app, add, systems } = useJobLauncher();
+  const { job, app, systems } = useJobLauncher();
 
   const [queues, setQueues] = useState<Array<Systems.LogicalQueue>>(
     getLogicalQueues(getSystem(systems, job.execSystemId))
@@ -77,21 +77,25 @@ const SystemSelector: React.FC = () => {
       const validSystems = isBatch
         ? systems.filter(system => !!system.batchLogicalQueues?.length)
         : systems;
-      const logicalQueue = isBatch
-        ? getLogicalQueue(app, validSystems, selectedSystem)
-        : undefined;
-      const system = getSystem(validSystems, selectedSystem);
-      const queues = getLogicalQueues(system);
       setSelectableSystems(validSystems);
+      if (!isBatch) {
+        setFieldValue('execSystemLogicalQueue', undefined);
+      }
+    },
+    [systems, isBatch, setFieldValue, setSelectableSystems]
+  )
+
+  useEffect(
+    () => {
+      const logicalQueue = isBatch
+        ? getLogicalQueue(app, selectableSystems, selectedSystem)
+        : undefined;
+      const system = getSystem(selectableSystems, selectedSystem);
+      const queues = getLogicalQueues(system);
       setQueues(queues);
       setFieldValue('execSystemLogicalQueue', logicalQueue);
-      add({
-        execSystemId: selectedSystem,
-        execSystemLogicalQueue: logicalQueue,
-      });
     },
-    /* eslint-disable-next-line */
-    [selectedSystem, isBatch, setQueues, setFieldValue]
+    [selectableSystems, isBatch, selectedSystem, app, setFieldValue, setQueues]
   );
 
   return (
@@ -125,6 +129,7 @@ const SystemSelector: React.FC = () => {
           label="Batch Logical Queue"
           required={false}
         >
+          <option value={undefined} />
           {queues.map((queue) => (
             <option value={queue.name} key={`queue-select-${queue.name}`}>
               {queue.name}

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -73,14 +73,6 @@ const SystemSelector: React.FC = () => {
     [values]
   );
 
-  const selectedSystemDefaultLogicalQueue = useMemo(() => {
-    const computedSystem = selectedSystem ?? app.jobAttributes?.execSystemId;
-    if (!computedSystem) {
-      return undefined;
-    }
-    return systems.find((system) => system.id === computedSystem)
-      ?.batchDefaultLogicalQueue;
-  }, [selectedSystem, systems, app]);
 
   useEffect(() => {
     const validSystems = isBatch
@@ -120,9 +112,7 @@ const SystemSelector: React.FC = () => {
         label="Execution System"
         required={true}
       >
-        <option value={undefined}>
-          Please select a system
-        </option>
+        <option value={undefined} />
         {selectableSystems.map((system) => (
           <option value={system.id} key={`execsystem-select-${system.id}`}>
             {system.id}
@@ -145,13 +135,7 @@ const SystemSelector: React.FC = () => {
           label="Batch Logical Queue"
           required={false}
         >
-          <option value={undefined}>
-            {app.jobAttributes?.execSystemLogicalQueue
-              ? `App default (${app.jobAttributes?.execSystemLogicalQueue})`
-              : selectedSystemDefaultLogicalQueue
-              ? `System default (${selectedSystemDefaultLogicalQueue})`
-              : 'Please select a logical queue'}
-          </option>
+          <option value={undefined} />
           {queues.map((queue) => (
             <option value={queue.name} key={`queue-select-${queue.name}`}>
               {queue.name}

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -73,6 +73,17 @@ const SystemSelector: React.FC = () => {
     [values]
   );
 
+  const selectedSystemDefaultLogicalQueue = useMemo(
+    () => {
+      const computedSystem = selectedSystem ?? app.jobAttributes?.execSystemId;
+      if (!computedSystem) {
+        return undefined;
+      }
+      return systems.find(system => system.id === computedSystem)?.batchDefaultLogicalQueue;
+    },
+    [ selectedSystem, systems, app ]
+  )
+
   useEffect(() => {
     const validSystems = isBatch
       ? systems.filter((system) => !!system.batchLogicalQueues?.length)
@@ -110,7 +121,7 @@ const SystemSelector: React.FC = () => {
         required={false}
       >
         <option value={undefined}>
-          (app default)
+          {app.jobAttributes?.execSystemId ? `App default (${app.jobAttributes?.execSystemId})`: `Please select a system`}
         </option>
         {selectableSystems.map((system) => (
           <option value={system.id} key={`execsystem-select-${system.id}`}>
@@ -135,7 +146,13 @@ const SystemSelector: React.FC = () => {
           required={false}
         >
           <option value={undefined}>
-            (app or system default)
+            {
+              app.jobAttributes?.execSystemLogicalQueue
+                ? `App default (${app.jobAttributes?.execSystemLogicalQueue})`
+                : selectedSystemDefaultLogicalQueue
+                  ? `System default (${selectedSystemDefaultLogicalQueue})`
+                  : 'Please select a logical queue'
+            }
           </option>
           {queues.map((queue) => (
             <option value={queue.name} key={`queue-select-${queue.name}`}>

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -9,6 +9,14 @@ import {
 } from 'tapis-ui/_common/FieldWrapperFormik';
 import { useFormikContext } from 'formik';
 import { Collapse } from 'tapis-ui/_common';
+import {
+  computeDefaultQueue,
+  computeDefaultSystem,
+  computeDefaultJobType,
+  validateExecSystem,
+  ValidateExecSystemResult,
+} from 'tapis-api/utils/jobExecSystem';
+import { capitalize } from './utils';
 import * as Yup from 'yup';
 import fieldArrayStyles from '../FieldArray.module.scss';
 import { JobStep, JobLauncherProviderParams } from '../';
@@ -18,39 +26,6 @@ const getLogicalQueues = (system?: Systems.TapisSystem) =>
 
 const getSystem = (systems: Array<Systems.TapisSystem>, systemId?: string) =>
   !!systemId ? systems.find((system) => system.id === systemId) : undefined;
-
-/**
- * Returns a default logical queue based on the following priority:
- * - If the selected system has the logical queue specified in the app, use that
- * - If the selected system has a default logical queue and the one in the app is not present, use that
- * - If no app logical queue is specified and no system default queue is specified, return undefined;
- */
-export const getLogicalQueue = (
-  app: Apps.TapisApp,
-  systems: Array<Systems.TapisSystem>,
-  systemId?: string
-): string | undefined => {
-  if (!systemId) {
-    return undefined;
-  }
-  const system = getSystem(systems, systemId);
-  if (!system) {
-    return undefined;
-  }
-  const queues = getLogicalQueues(system);
-  if (!!app.jobAttributes?.execSystemLogicalQueue) {
-    const selectedSystemHasAppDefault = queues.some(
-      (queue) => queue.name === app.jobAttributes?.execSystemLogicalQueue
-    );
-    if (selectedSystemHasAppDefault) {
-      return app.jobAttributes?.execSystemLogicalQueue;
-    }
-  }
-  if (!!system.batchDefaultLogicalQueue) {
-    return system.batchDefaultLogicalQueue;
-  }
-  return undefined;
-};
 
 const SystemSelector: React.FC = () => {
   const { setFieldValue, values } = useFormikContext();
@@ -63,17 +38,49 @@ const SystemSelector: React.FC = () => {
   const [selectableSystems, setSelectableSystems] =
     useState<Array<Systems.TapisSystem>>(systems);
 
-  const selectedSystem = useMemo(
-    () => (values as Jobs.ReqSubmitJob)?.execSystemId,
-    [values]
-  );
-
-  const isBatch = useMemo(
-    () => (values as Jobs.ReqSubmitJob)?.jobType === Apps.JobTypeEnum.Batch,
-    [values]
-  );
+  const {
+    defaultSystemLabel,
+    defaultQueueLabel,
+    defaultJobTypeLabel,
+    isBatch,
+    selectedSystem,
+  } = useMemo(() => {
+    // Compute labels for when undefined values are selected for systems, queues or jobType
+    const { source: systemSource, systemId } = computeDefaultSystem(app);
+    const defaultSystemLabel = systemSource
+      ? `App default (${systemId})`
+      : 'Please select a system';
+    const { source: queueSource, queue } = computeDefaultQueue(
+      values as Partial<Jobs.ReqSubmitJob>,
+      app,
+      systems
+    );
+    const defaultQueueLabel = queueSource
+      ? `${capitalize(queueSource)} default (${queue})`
+      : 'Please select a queue';
+    const { source: jobTypeSource, jobType } = computeDefaultJobType(
+      values as Partial<Jobs.ReqSubmitJob>,
+      app,
+      systems
+    );
+    const defaultJobTypeLabel = `${capitalize(
+      jobTypeSource
+    )} default (${jobType})`;
+    const isBatch =
+      (values as Jobs.ReqSubmitJob)?.jobType === Apps.JobTypeEnum.Batch ||
+      jobType === Apps.JobTypeEnum.Batch;
+    const selectedSystem = (values as Jobs.ReqSubmitJob)?.execSystemId;
+    return {
+      defaultSystemLabel,
+      defaultQueueLabel,
+      defaultJobTypeLabel,
+      isBatch,
+      selectedSystem,
+    };
+  }, [values, app, systems]);
 
   useEffect(() => {
+    // Handle changes to selectable execSystems and execSystemLogicalQueues
     const validSystems = isBatch
       ? systems.filter((system) => !!system.batchLogicalQueues?.length)
       : systems;
@@ -81,18 +88,18 @@ const SystemSelector: React.FC = () => {
     if (!validSystems.some((system) => system.id === selectedSystem)) {
       // If current system is invalid (like a system with no logical queues for a batch job)
       // then use the application default
-      setFieldValue('execSystemId', app.jobAttributes?.execSystemId);
+      setFieldValue('execSystemId', undefined);
     }
     if (!isBatch) {
       setFieldValue('execSystemLogicalQueue', undefined);
     }
-    const logicalQueue = isBatch
-      ? getLogicalQueue(app, validSystems, selectedSystem)
-      : undefined;
-    const system = getSystem(validSystems, selectedSystem);
+    const system = getSystem(
+      validSystems,
+      selectedSystem ?? app.jobAttributes?.execSystemId
+    );
     const queues = getLogicalQueues(system);
     setQueues(queues);
-    setFieldValue('execSystemLogicalQueue', logicalQueue);
+    setFieldValue('execSystemLogicalQueue', undefined);
   }, [
     systems,
     isBatch,
@@ -110,12 +117,16 @@ const SystemSelector: React.FC = () => {
         description="The execution system for this job"
         label="Execution System"
         required={true}
+        data-testid="execSystemId"
       >
-        <option value={undefined} />
+        <option value={undefined} label={defaultSystemLabel} />
         {selectableSystems.map((system) => (
-          <option value={system.id} key={`execsystem-select-${system.id}`}>
-            {system.id}
-          </option>
+          <option
+            value={system.id}
+            key={`execsystem-select-${system.id}`}
+            label={system.id}
+            data-testid={`execSystemId-${system.id}`}
+          />
         ))}
       </FormikSelect>
       <FormikSelect
@@ -123,9 +134,11 @@ const SystemSelector: React.FC = () => {
         label="Job Type"
         description="Jobs can either be Batch or Fork"
         required={true}
+        data-testid="jobType"
       >
-        <option value={Apps.JobTypeEnum.Batch}>Batch</option>
-        <option value={Apps.JobTypeEnum.Fork}>Fork</option>
+        <option value={undefined} label={defaultJobTypeLabel} />
+        <option value={Apps.JobTypeEnum.Batch} label="Batch" />
+        <option value={Apps.JobTypeEnum.Fork} label="Fork" />
       </FormikSelect>
       {isBatch && (
         <FormikSelect
@@ -133,12 +146,16 @@ const SystemSelector: React.FC = () => {
           description="The batch queue on this execution system"
           label="Batch Logical Queue"
           required={false}
+          disabled={queues.length === 0}
+          data-testid="execSystemLogicalQueue"
         >
-          <option value={undefined} />
+          <option value={undefined} label={defaultQueueLabel} />
           {queues.map((queue) => (
-            <option value={queue.name} key={`queue-select-${queue.name}`}>
-              {queue.name}
-            </option>
+            <option
+              value={queue.name}
+              key={`queue-select-${queue.name}`}
+              label={queue.name}
+            />
           ))}
         </FormikSelect>
       )}
@@ -281,21 +298,37 @@ export const ExecOptions: React.FC = () => {
 };
 
 export const ExecOptionsSummary: React.FC = () => {
-  const { job } = useJobLauncher();
-  const { execSystemId, execSystemLogicalQueue, isMpi, mpiCmd, cmdPrefix } =
-    job;
-  const summary = execSystemId
-    ? `${execSystemId} ${
-        execSystemLogicalQueue ? '(' + execSystemLogicalQueue + ')' : ''
-      }`
-    : undefined;
+  const { job, app, systems } = useJobLauncher();
+  const { isMpi, mpiCmd, cmdPrefix } = job;
+
+  const { computedSystem, computedQueue, computedJobType } = useMemo(() => {
+    const { execSystemLogicalQueue, execSystemId, jobType } = job;
+    const computedSystem = execSystemId ?? computeDefaultSystem(app)?.systemId;
+    const computedQueue =
+      execSystemLogicalQueue ?? computeDefaultQueue(job, app, systems)?.queue;
+    const computedJobType =
+      jobType ?? computeDefaultJobType(job, app, systems)?.jobType;
+    return {
+      computedSystem,
+      computedQueue,
+      computedJobType,
+    };
+  }, [job, app, systems]);
+
   return (
     <div>
       <StepSummaryField
-        field={summary}
+        field={computedSystem}
         error="An execution system is required"
         key="execution-system-id-summary"
       />
+      {computedJobType === Apps.JobTypeEnum.Batch && (
+        <StepSummaryField
+          field={computedQueue}
+          error="A logical queue is required"
+          key="execution-system-queue-summary"
+        />
+      )}
       <StepSummaryField
         field={`${
           isMpi
@@ -314,7 +347,7 @@ const validationSchema = Yup.object({
   execSystemExecDir: Yup.string(),
   execSystemInputDir: Yup.string(),
   execSystemOutputDir: Yup.string(),
-  jobType: Yup.string().required(),
+  jobType: Yup.string(),
   nodeCount: Yup.number(),
   coresPerNode: Yup.number(),
   memoryMB: Yup.number(),
@@ -346,37 +379,61 @@ const validateThunk = ({ app, systems }: JobLauncherProviderParams) => {
     } = values;
     const errors: QueueErrors = {};
 
-    const computedExecSystemId =
-      execSystemId ?? app.jobAttributes?.execSystemId;
-    if (!computedExecSystemId) {
+    const validation = validateExecSystem(
+      values as Partial<Jobs.ReqSubmitJob>,
+      app,
+      systems
+    );
+    if (validation === ValidateExecSystemResult.ErrorNoExecSystem) {
       errors.execSystemId = `This app does not have a default execution system. You must specify one for this job`;
+    }
+
+    if (validation === ValidateExecSystemResult.ErrorExecSystemNotFound) {
+      errors.execSystemId = `The specified exec system cannot be found`;
+    }
+
+    if (validation === ValidateExecSystemResult.ErrorExecSystemNoQueues) {
+      errors.execSystemId = `The specified exec system is not capable of batch jobs`;
+    }
+
+    if (validation === ValidateExecSystemResult.ErrorNoQueue) {
+      errors.execSystemLogicalQueue = `Neither the application nor the selected system specifies a default queue. You must specify one for this job`;
+    }
+
+    if (validation === ValidateExecSystemResult.ErrorQueueNotFound) {
+      errors.execSystemLogicalQueue = `The specified queue cannot be found on the selected system`;
+    }
+
+    // Skip queue validation if the job is a FORK job
+    if (
+      jobType === Apps.JobTypeEnum.Fork ||
+      computeDefaultJobType(values as Partial<Jobs.ReqSubmitJob>, app, systems)
+        ?.jobType === Apps.JobTypeEnum.Fork
+    ) {
       return errors;
     }
 
-    if (jobType !== Apps.JobTypeEnum.Batch) {
+    const computedExecSystem = computeDefaultSystem(app);
+    const computedLogicalQueue = computeDefaultQueue(
+      values as Partial<Jobs.ReqSubmitJob>,
+      app,
+      systems
+    );
+    const selectedSystem = systems.find(
+      (system) => system.id === (execSystemId ?? computedExecSystem.systemId)
+    );
+
+    if (!selectedSystem?.batchLogicalQueues?.length) {
+      errors.execSystemLogicalQueue = `The selected system does not have any batch logical queues`;
       return errors;
     }
 
-    const systemDefaultLogicalQueue = systems.find(
-      (system) => system.id === computedExecSystemId
-    )?.batchDefaultLogicalQueue;
-    const computedLogicalQueue =
-      execSystemLogicalQueue ??
-      app.jobAttributes?.execSystemLogicalQueue ??
-      systemDefaultLogicalQueue;
-
-    if (!computedLogicalQueue) {
-      errors.execSystemLogicalQueue = `This app does not specify a default logical queue. You must specify one for this batch job`;
-      return errors;
-    }
-
-    const queue = systems
-      .find((system) => system.id === computedExecSystemId)
-      ?.batchLogicalQueues?.find(
-        (queue) => queue.name === computedLogicalQueue
-      );
+    const queue = selectedSystem?.batchLogicalQueues?.find(
+      (queue) =>
+        queue.name === (execSystemLogicalQueue ?? computedLogicalQueue?.queue)
+    );
     if (!queue) {
-      errors.execSystemLogicalQueue = `The specified logical queue does not exist on the selected execution system`;
+      errors.execSystemLogicalQueue = `The specified queue does not exist on the selected execution system`;
       return errors;
     }
 
@@ -421,10 +478,8 @@ const generateInitialValues = ({
   app,
   systems,
 }: JobLauncherProviderParams): Partial<Jobs.ReqSubmitJob> => ({
-  execSystemId: job.execSystemId ?? app.jobAttributes?.execSystemId,
-  execSystemLogicalQueue: job.execSystemId
-    ? getLogicalQueue(app, systems, job.execSystemId)
-    : undefined,
+  execSystemId: job.execSystemId,
+  execSystemLogicalQueue: job.execSystemLogicalQueue,
   jobType: job.jobType,
   execSystemExecDir: job.execSystemExecDir,
   execSystemInputDir: job.execSystemInputDir,

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -120,7 +120,9 @@ const SystemSelector: React.FC = () => {
         label="Execution System"
         required={true}
       >
-        <option value={undefined} />
+        <option value={undefined}>
+          Please select a system
+        </option>
         {selectableSystems.map((system) => (
           <option value={system.id} key={`execsystem-select-${system.id}`}>
             {system.id}

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -73,7 +73,6 @@ const SystemSelector: React.FC = () => {
     [values]
   );
 
-
   useEffect(() => {
     const validSystems = isBatch
       ? systems.filter((system) => !!system.batchLogicalQueues?.length)

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/JobSubmit.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/JobSubmit.tsx
@@ -4,6 +4,10 @@ import { JSONDisplay } from 'tapis-ui/_common';
 import { fileInputsComplete } from 'tapis-api/utils/jobFileInputs';
 import { fileInputArraysComplete } from 'tapis-api/utils/jobFileInputArrays';
 import { jobRequiredFieldsComplete } from 'tapis-api/utils/jobRequiredFields';
+import {
+  validateExecSystem,
+  ValidateExecSystemResult,
+} from 'tapis-api/utils/jobExecSystem';
 import { StepSummaryField } from '../components';
 import { SubmitWrapper } from 'tapis-ui/_wrappers';
 import { Jobs } from '@tapis/tapis-typescript';
@@ -13,8 +17,10 @@ import { Button } from 'reactstrap';
 import arrayStyles from '../FieldArray.module.scss';
 
 export const JobSubmit: React.FC = () => {
-  const { job, app } = useJobLauncher();
+  const { job, app, systems } = useJobLauncher();
   const isComplete =
+    validateExecSystem(job, app, systems) ===
+      ValidateExecSystemResult.Complete &&
     jobRequiredFieldsComplete(job) &&
     fileInputsComplete(app, job.fileInputs ?? []) &&
     fileInputArraysComplete(app, job.fileInputArrays ?? []);
@@ -64,8 +70,9 @@ export const JobSubmit: React.FC = () => {
 };
 
 export const JobSubmitSummary: React.FC = () => {
-  const { app, job } = useJobLauncher();
+  const { app, job, systems } = useJobLauncher();
   const isComplete =
+    validateExecSystem(job, app, systems) &&
     jobRequiredFieldsComplete(job) &&
     fileInputsComplete(app, job.fileInputs ?? []) &&
     fileInputArraysComplete(app, job.fileInputArrays ?? []);

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/utils.ts
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/utils.ts
@@ -3,6 +3,10 @@ export const upperCaseFirstLetter = (str: string) => {
   return `${lower.slice(0, 1).toUpperCase()}${lower.slice(1)}`;
 };
 
+export const capitalize = (str: string) => {
+  return str!.charAt(0).toUpperCase() + str!.slice(1);
+};
+
 export const reduceRecord = (record: Record<'id', string>) => {
   const { id, ...contents } = record;
   return Object.values(contents).reduce(


### PR DESCRIPTION
## Overview:

- Revise Exec System Option behavior when selecting batch or fork job types

## Related Github Issues:

- [TUI-314](https://github.com/tapis-project/tapis-ui/issues/314)

## Summary of Changes:

- Exec system or queue selection changes values after form validation (was previously setting value upon dropdown selection, which does not follow form validation life cycle in other steps)
- Upon selecting fork jobs, hide batch queue options and allow selection of any exec system
- Upon selecting batch jobs, filter selectable systems for those with batch logical queues
- Allow undefined values for execSystemId, execSystemLogicalQueue, jobType that fall back upon defaults based on documented TAPIS logic
- Utility functions for computing default values, validating exec system selections

## Testing Steps:

1. Try changing exec system job types
2. Try selecting different queues
3. Try invalid options for queues (for example, entering in too many nodes)
4. Test this with bsf v1, SleepSeconds, NoExecSystem app

## UI Photos:

## Notes:
