### PR TITLE
task/TUI-314 -- allow undefined values for app/system defaults

### DIFF
--- a/src/tapis-api/utils/jobDefaults.ts
+++ b/src/tapis-api/utils/jobDefaults.ts
@@ -13,9 +13,7 @@ const generateJobDefaults = ({
   if (!app) {
     return {};
   }
-  const systemDefaultQueue = systems.find(
-    (system) => system.id === app.jobAttributes?.execSystemId
-  )?.batchDefaultLogicalQueue;
+
   const defaultValues: Partial<Jobs.ReqSubmitJob> = {
     name: `${app.id}-${app.version}`,
     description: app.description,
@@ -32,9 +30,6 @@ const generateJobDefaults = ({
     isMpi: app.jobAttributes?.isMpi,
     mpiCmd: app.jobAttributes?.mpiCmd,
     cmdPrefix: app.jobAttributes?.cmdPrefix,
-    execSystemId: app.jobAttributes?.execSystemId,
-    execSystemLogicalQueue:
-      app.jobAttributes?.execSystemLogicalQueue ?? systemDefaultQueue,
     fileInputs: generateRequiredFileInputsFromApp(app),
     fileInputArrays: generateRequiredFileInputArraysFromApp(app),
     parameterSet: {

--- a/src/tapis-api/utils/jobExecSystem.test.ts
+++ b/src/tapis-api/utils/jobExecSystem.test.ts
@@ -10,7 +10,10 @@ import {
 
 describe('Job Exec System utils', () => {
   it('determines default system', () => {
-    expect(computeDefaultSystem(tapisApp)).toEqual({ source: "app", systemId: "testuser2.execution"});
+    expect(computeDefaultSystem(tapisApp)).toEqual({
+      source: 'app',
+      systemId: 'testuser2.execution',
+    });
   });
   it('determines the default logical queue from an app', () => {
     expect(computeDefaultQueue({}, tapisApp, [tapisSystem])).toEqual({

--- a/src/tapis-api/utils/jobExecSystem.test.ts
+++ b/src/tapis-api/utils/jobExecSystem.test.ts
@@ -5,7 +5,7 @@ import { tapisSystem } from 'fixtures/systems.fixtures';
 import {
   computeDefaultQueue,
   computeDefaultSystem,
-  execSystemComplete
+  execSystemComplete,
 } from './jobExecSystem';
 
 describe('Job Exec System utils', () => {
@@ -14,50 +14,74 @@ describe('Job Exec System utils', () => {
   });
   it('determines the default logical queue from an app', () => {
     expect(computeDefaultQueue({}, tapisApp, [tapisSystem])).toEqual({
-      source: "app",
-      queue: 'tapisNormal'
-    })
+      source: 'app',
+      queue: 'tapisNormal',
+    });
   });
   it('determines the default logical queue from a system default', () => {
-    const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    const tapisAppNoQueue = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
     tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
     expect(computeDefaultQueue({}, tapisAppNoQueue, [tapisSystem])).toEqual({
-      source: "system",
-      queue: 'tapisNormal'
-    })
+      source: 'system',
+      queue: 'tapisNormal',
+    });
   });
   it('determines the default logical queue from a system default, where the system is selected by the job', () => {
-    const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    const tapisAppNoQueue = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
     tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
-    expect(computeDefaultQueue({ execSystemId: 'testuser2.execution'}, tapisAppNoQueue, [tapisSystem])).toEqual({
-      source: "system",
-      queue: 'tapisNormal'
-    }) 
+    expect(
+      computeDefaultQueue(
+        { execSystemId: 'testuser2.execution' },
+        tapisAppNoQueue,
+        [tapisSystem]
+      )
+    ).toEqual({
+      source: 'system',
+      queue: 'tapisNormal',
+    });
   });
   it('determines that there is no computed queue if a system does not exist', () => {
-    const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    const tapisAppNoQueue = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
     tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
     expect(computeDefaultQueue({}, tapisAppNoQueue, [])).toEqual({
       source: undefined,
-      queue: undefined
-    })
+      queue: undefined,
+    });
   });
   it('detects a complete job request that satisfies exec system options', () => {
     expect(execSystemComplete({}, tapisApp, [tapisSystem])).toBe(true);
   });
   it('detects a complete job request if a job is a Fork job', () => {
-    expect(execSystemComplete({ jobType: Apps.JobTypeEnum.Fork }, tapisApp, [tapisSystem])).toBe(true);
+    expect(
+      execSystemComplete({ jobType: Apps.JobTypeEnum.Fork }, tapisApp, [
+        tapisSystem,
+      ])
+    ).toBe(true);
   });
-  it ('detects an incomplete job request if an exec system is not specified', () => {
-    const tapisAppNoSystem = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+  it('detects an incomplete job request if an exec system is not specified', () => {
+    const tapisAppNoSystem = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
     tapisAppNoSystem.jobAttributes!.execSystemId = undefined;
     expect(execSystemComplete({}, tapisAppNoSystem, [])).toBe(false);
   });
   it('detects an incomplete job request if a queue cannot be found', () => {
-    const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    const tapisAppNoQueue = JSON.parse(
+      JSON.stringify(tapisApp)
+    ) as Apps.TapisApp;
     tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
-    const tapisSystemNoDefaultQueue = (JSON.parse(JSON.stringify(tapisSystem)) as Systems.TapisSystem);
-    tapisSystemNoDefaultQueue.batchDefaultLogicalQueue = undefined; 
-    expect(execSystemComplete({}, tapisAppNoQueue, [tapisSystemNoDefaultQueue])).toBe(false);
+    const tapisSystemNoDefaultQueue = JSON.parse(
+      JSON.stringify(tapisSystem)
+    ) as Systems.TapisSystem;
+    tapisSystemNoDefaultQueue.batchDefaultLogicalQueue = undefined;
+    expect(
+      execSystemComplete({}, tapisAppNoQueue, [tapisSystemNoDefaultQueue])
+    ).toBe(false);
   });
 });

--- a/src/tapis-api/utils/jobExecSystem.test.ts
+++ b/src/tapis-api/utils/jobExecSystem.test.ts
@@ -22,7 +22,7 @@ describe('Job Exec System utils', () => {
       queue: 'tapisNormal',
     });
   });
-  it('determines the default logical queue from a system default', () => {
+  it('determines the default logical queue from the default system specified by the app', () => {
     const tapisAppNoQueue = JSON.parse(
       JSON.stringify(tapisApp)
     ) as Apps.TapisApp;
@@ -58,7 +58,7 @@ describe('Job Exec System utils', () => {
       queue: undefined,
     });
   });
-  it('detects a complete job request that satisfies exec system options', () => {
+  it('detects a valid job request that satisfies exec system options', () => {
     expect(validateExecSystem({}, tapisApp, [tapisSystem])).toBe(
       ValidateExecSystemResult.Complete
     );

--- a/src/tapis-api/utils/jobExecSystem.test.ts
+++ b/src/tapis-api/utils/jobExecSystem.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe('Job Exec System utils', () => {
   it('determines default system', () => {
-    expect(computeDefaultSystem(tapisApp)).toEqual('testuser2.execution');
+    expect(computeDefaultSystem(tapisApp)).toEqual({ source: "app", systemId: "testuser2.execution"});
   });
   it('determines the default logical queue from an app', () => {
     expect(computeDefaultQueue({}, tapisApp, [tapisSystem])).toEqual({
@@ -24,7 +24,7 @@ describe('Job Exec System utils', () => {
     ) as Apps.TapisApp;
     tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
     expect(computeDefaultQueue({}, tapisAppNoQueue, [tapisSystem])).toEqual({
-      source: 'system',
+      source: 'app system',
       queue: 'tapisNormal',
     });
   });

--- a/src/tapis-api/utils/jobExecSystem.test.ts
+++ b/src/tapis-api/utils/jobExecSystem.test.ts
@@ -1,0 +1,63 @@
+import { Apps, Systems } from '@tapis/tapis-typescript';
+import '@testing-library/jest-dom/extend-expect';
+import { tapisApp } from 'fixtures/apps.fixtures';
+import { tapisSystem } from 'fixtures/systems.fixtures';
+import {
+  computeDefaultQueue,
+  computeDefaultSystem,
+  execSystemComplete
+} from './jobExecSystem';
+
+describe('Job Exec System utils', () => {
+  it('determines default system', () => {
+    expect(computeDefaultSystem(tapisApp)).toEqual('testuser2.execution');
+  });
+  it('determines the default logical queue from an app', () => {
+    expect(computeDefaultQueue({}, tapisApp, [tapisSystem])).toEqual({
+      source: tapisApp,
+      queue: 'tapisNormal'
+    })
+  });
+  it('determines the default logical queue from a system default', () => {
+    const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
+    expect(computeDefaultQueue({}, tapisAppNoQueue, [tapisSystem])).toEqual({
+      source: tapisSystem,
+      queue: 'tapisNormal'
+    })
+  });
+  it('determines the default logical queue from a system default, where the system is selected by the job', () => {
+    const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
+    expect(computeDefaultQueue({ execSystemId: 'testuser2.execution'}, tapisAppNoQueue, [tapisSystem])).toEqual({
+      source: tapisSystem,
+      queue: 'tapisNormal'
+    }) 
+  });
+  it('determines that there is no computed queue if a system does not exist', () => {
+    const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
+    expect(computeDefaultQueue({}, tapisAppNoQueue, [])).toEqual({
+      source: undefined,
+      queue: undefined
+    })
+  });
+  it('detects a complete job request that satisfies exec system options', () => {
+    expect(execSystemComplete({}, tapisApp, [tapisSystem])).toBe(true);
+  });
+  it('detects a complete job request if a job is a Fork job', () => {
+    expect(execSystemComplete({ jobType: Apps.JobTypeEnum.Fork }, tapisApp, [tapisSystem])).toBe(true);
+  });
+  it ('detects an incomplete job request if an exec system is not specified', () => {
+    const tapisAppNoSystem = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    tapisAppNoSystem.jobAttributes!.execSystemId = undefined;
+    expect(execSystemComplete({}, tapisAppNoSystem, [])).toBe(false);
+  });
+  it('detects an incomplete job request if a queue cannot be found', () => {
+    const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
+    tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
+    const tapisSystemNoDefaultQueue = (JSON.parse(JSON.stringify(tapisSystem)) as Systems.TapisSystem);
+    tapisSystemNoDefaultQueue.batchDefaultLogicalQueue = undefined; 
+    expect(execSystemComplete({}, tapisAppNoQueue, [tapisSystemNoDefaultQueue])).toBe(false);
+  });
+});

--- a/src/tapis-api/utils/jobExecSystem.test.ts
+++ b/src/tapis-api/utils/jobExecSystem.test.ts
@@ -14,7 +14,7 @@ describe('Job Exec System utils', () => {
   });
   it('determines the default logical queue from an app', () => {
     expect(computeDefaultQueue({}, tapisApp, [tapisSystem])).toEqual({
-      source: tapisApp,
+      source: "app",
       queue: 'tapisNormal'
     })
   });
@@ -22,7 +22,7 @@ describe('Job Exec System utils', () => {
     const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
     tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
     expect(computeDefaultQueue({}, tapisAppNoQueue, [tapisSystem])).toEqual({
-      source: tapisSystem,
+      source: "system",
       queue: 'tapisNormal'
     })
   });
@@ -30,7 +30,7 @@ describe('Job Exec System utils', () => {
     const tapisAppNoQueue = (JSON.parse(JSON.stringify(tapisApp)) as Apps.TapisApp);
     tapisAppNoQueue.jobAttributes!.execSystemLogicalQueue = undefined;
     expect(computeDefaultQueue({ execSystemId: 'testuser2.execution'}, tapisAppNoQueue, [tapisSystem])).toEqual({
-      source: tapisSystem,
+      source: "system",
       queue: 'tapisNormal'
     }) 
   });

--- a/src/tapis-api/utils/jobExecSystem.ts
+++ b/src/tapis-api/utils/jobExecSystem.ts
@@ -6,14 +6,14 @@ export const computeDefaultSystem = (app: Apps.TapisApp) => {
 }
 
 type DefaultQueue = {
-  source?: Apps.TapisApp | Systems.TapisSystem;
+  source?: "app" | "system";
   queue?: string;
 }
 
 export const computeDefaultQueue = (job: Partial<Jobs.ReqSubmitJob>, app: Apps.TapisApp, systems: Array<Systems.TapisSystem>): DefaultQueue => {
   if (app.jobAttributes?.execSystemLogicalQueue) {
     return {
-      source: app,
+      source: "app",
       queue: app.jobAttributes?.execSystemLogicalQueue
     }
   }
@@ -21,7 +21,7 @@ export const computeDefaultQueue = (job: Partial<Jobs.ReqSubmitJob>, app: Apps.T
   const defaultSystem = systems.find(system => system.id === selectedSystem);
   if (defaultSystem && defaultSystem.batchDefaultLogicalQueue) {
     return {
-      source: defaultSystem,
+      source: "system",
       queue: defaultSystem.batchDefaultLogicalQueue
     }
   }

--- a/src/tapis-api/utils/jobExecSystem.ts
+++ b/src/tapis-api/utils/jobExecSystem.ts
@@ -1,0 +1,58 @@
+import { Apps, Jobs, Systems } from "@tapis/tapis-typescript";
+
+
+export const computeDefaultSystem = (app: Apps.TapisApp) => {
+  return app.jobAttributes?.execSystemId;
+}
+
+type DefaultQueue = {
+  source?: Apps.TapisApp | Systems.TapisSystem;
+  queue?: string;
+}
+
+export const computeDefaultQueue = (job: Partial<Jobs.ReqSubmitJob>, app: Apps.TapisApp, systems: Array<Systems.TapisSystem>): DefaultQueue => {
+  if (app.jobAttributes?.execSystemLogicalQueue) {
+    return {
+      source: app,
+      queue: app.jobAttributes?.execSystemLogicalQueue
+    }
+  }
+  const selectedSystem = job.execSystemId ?? app.jobAttributes?.execSystemId;
+  const defaultSystem = systems.find(system => system.id === selectedSystem);
+  if (defaultSystem && defaultSystem.batchDefaultLogicalQueue) {
+    return {
+      source: defaultSystem,
+      queue: defaultSystem.batchDefaultLogicalQueue
+    }
+  }
+  return {
+    source: undefined,
+    queue: undefined
+  }
+}
+
+export const execSystemComplete = (job: Partial<Jobs.ReqSubmitJob>, app: Apps.TapisApp, systems: Array<Systems.TapisSystem>) => {
+  const defaultSystem = computeDefaultSystem(app);
+
+  // Check that an exec system can be computed
+  if (!job.execSystemId && !defaultSystem) {
+    return false;
+  }
+
+  // Check that a job type has been specified
+  if (!job.jobType && !app.jobType) {
+    return false;
+  }
+  // If the job type will be a batch job, ensure that a queue is specified
+  if ((!!job.jobType && job.jobType === Apps.JobTypeEnum.Batch) || (!job.jobType && app.jobType === Apps.JobTypeEnum.Batch)) {
+    // Check to see if the job has a specified queue
+    if (!job.execSystemLogicalQueue) {
+      // If no queue exists, there must be a fallback to the app or system default
+      const defaultQueue = computeDefaultQueue(job, app, systems);
+      if (!defaultQueue.source) {
+        return false;
+      }
+    }
+  }
+  return true;
+}

--- a/src/tapis-api/utils/jobExecSystem.ts
+++ b/src/tapis-api/utils/jobExecSystem.ts
@@ -1,38 +1,135 @@
 import { Apps, Jobs, Systems } from '@tapis/tapis-typescript';
 
-export const computeDefaultSystem = (app: Apps.TapisApp) => {
-  return app.jobAttributes?.execSystemId;
+type DefaultSystem = {
+  source?: 'app'
+  systemId?: string
+}
+
+/**
+ * Computes the default execution system ID that will be used
+ * 
+ * @param app
+ * @returns 
+ */
+export const computeDefaultSystem = (app: Apps.TapisApp): DefaultSystem => {
+  if (app.jobAttributes?.execSystemId) {
+    return {
+      source: 'app',
+      systemId: app.jobAttributes?.execSystemId
+    }
+  }
+  return {
+    source: undefined,
+    systemId: undefined
+  }
 };
 
 type DefaultQueue = {
-  source?: 'app' | 'system';
+  source?: 'app' | 'system' | 'app system';
   queue?: string;
 };
 
+/**
+ * Computes the logical queue that will be used, if the job does not
+ * specify one
+ * 
+ * @param job
+ * @param app 
+ * @param systems 
+ * @returns 
+ */
 export const computeDefaultQueue = (
   job: Partial<Jobs.ReqSubmitJob>,
   app: Apps.TapisApp,
   systems: Array<Systems.TapisSystem>
 ): DefaultQueue => {
+  // If the app specifies the logical queue, use that
   if (app.jobAttributes?.execSystemLogicalQueue) {
     return {
       source: 'app',
       queue: app.jobAttributes?.execSystemLogicalQueue,
     };
   }
-  const selectedSystem = job.execSystemId ?? app.jobAttributes?.execSystemId;
-  const defaultSystem = systems.find((system) => system.id === selectedSystem);
-  if (defaultSystem && defaultSystem.batchDefaultLogicalQueue) {
-    return {
-      source: 'system',
-      queue: defaultSystem.batchDefaultLogicalQueue,
-    };
+
+  // If the job specifies a system, look for its default logical queue
+  if (job.execSystemId) {
+    const selectedSystem = systems.find((system) => system.id === job.execSystemId);
+    if (selectedSystem?.batchDefaultLogicalQueue) {
+      return {
+        source: 'system',
+        queue: selectedSystem.batchDefaultLogicalQueue
+      } 
+    }
   }
+
+  // If the app specifies a system, look for its default logical queue
+  if (app.jobAttributes?.execSystemId) {
+    const appSystem = systems.find((system) => system.id === app.jobAttributes?.execSystemId);
+    if (appSystem?.batchDefaultLogicalQueue) {
+      return {
+        source: 'app system',
+        queue: appSystem.batchDefaultLogicalQueue
+      }
+    }
+  }
+
+  // Return a result that has no computed default logical queue
   return {
     source: undefined,
     queue: undefined,
   };
 };
+
+type DefaultJobType = {
+  source: 'app' | 'app system' | 'system' | 'tapis',
+  jobType: Apps.JobTypeEnum
+}
+
+/**
+ * Determines the default jobType if one is not specified in the jobType field in a job
+ * using the algorithm specified at:
+ * 
+ * https://tapis.readthedocs.io/en/latest/technical/jobs.html#job-type
+ * 
+ * @param job 
+ * @param app 
+ * @param systems 
+ * @returns 
+ */
+export const computeDefaultJobType = (
+  job: Partial<Jobs.ReqSubmitJob>,
+  app: Apps.TapisApp,
+  systems: Array<Systems.TapisSystem>,
+): DefaultJobType => {
+  if (app.jobType) {
+    return {
+      source: 'app',
+      jobType: app.jobType!
+    }
+  }
+  if (job?.execSystemId) {
+    const selectedSystem = systems.find(system => system.id === job.execSystemId);
+    if (selectedSystem?.canRunBatch) {
+      return {
+        source: 'system',
+        jobType: Apps.JobTypeEnum.Batch
+      }
+    }
+  }
+  if (app.jobAttributes?.execSystemId) {
+    const appSystem = systems.find(system => system.id === app.jobAttributes?.execSystemId);
+    if (appSystem?.canRunBatch) {
+      return {
+        source: 'app system',
+        jobType: Apps.JobTypeEnum.Batch
+      }
+    }
+  }
+  return {
+    source: 'tapis',
+    jobType: Apps.JobTypeEnum.Fork
+  }
+}
 
 export const execSystemComplete = (
   job: Partial<Jobs.ReqSubmitJob>,

--- a/src/tapis-api/utils/jobExecSystem.ts
+++ b/src/tapis-api/utils/jobExecSystem.ts
@@ -139,7 +139,7 @@ export const execSystemComplete = (
   const defaultSystem = computeDefaultSystem(app);
 
   // Check that an exec system can be computed
-  if (!job.execSystemId && !defaultSystem) {
+  if (!job.execSystemId && !defaultSystem?.systemId) {
     return false;
   }
 

--- a/src/tapis-api/utils/jobExecSystem.ts
+++ b/src/tapis-api/utils/jobExecSystem.ts
@@ -1,37 +1,44 @@
-import { Apps, Jobs, Systems } from "@tapis/tapis-typescript";
-
+import { Apps, Jobs, Systems } from '@tapis/tapis-typescript';
 
 export const computeDefaultSystem = (app: Apps.TapisApp) => {
   return app.jobAttributes?.execSystemId;
-}
+};
 
 type DefaultQueue = {
-  source?: "app" | "system";
+  source?: 'app' | 'system';
   queue?: string;
-}
+};
 
-export const computeDefaultQueue = (job: Partial<Jobs.ReqSubmitJob>, app: Apps.TapisApp, systems: Array<Systems.TapisSystem>): DefaultQueue => {
+export const computeDefaultQueue = (
+  job: Partial<Jobs.ReqSubmitJob>,
+  app: Apps.TapisApp,
+  systems: Array<Systems.TapisSystem>
+): DefaultQueue => {
   if (app.jobAttributes?.execSystemLogicalQueue) {
     return {
-      source: "app",
-      queue: app.jobAttributes?.execSystemLogicalQueue
-    }
+      source: 'app',
+      queue: app.jobAttributes?.execSystemLogicalQueue,
+    };
   }
   const selectedSystem = job.execSystemId ?? app.jobAttributes?.execSystemId;
-  const defaultSystem = systems.find(system => system.id === selectedSystem);
+  const defaultSystem = systems.find((system) => system.id === selectedSystem);
   if (defaultSystem && defaultSystem.batchDefaultLogicalQueue) {
     return {
-      source: "system",
-      queue: defaultSystem.batchDefaultLogicalQueue
-    }
+      source: 'system',
+      queue: defaultSystem.batchDefaultLogicalQueue,
+    };
   }
   return {
     source: undefined,
-    queue: undefined
-  }
-}
+    queue: undefined,
+  };
+};
 
-export const execSystemComplete = (job: Partial<Jobs.ReqSubmitJob>, app: Apps.TapisApp, systems: Array<Systems.TapisSystem>) => {
+export const execSystemComplete = (
+  job: Partial<Jobs.ReqSubmitJob>,
+  app: Apps.TapisApp,
+  systems: Array<Systems.TapisSystem>
+) => {
   const defaultSystem = computeDefaultSystem(app);
 
   // Check that an exec system can be computed
@@ -44,7 +51,10 @@ export const execSystemComplete = (job: Partial<Jobs.ReqSubmitJob>, app: Apps.Ta
     return false;
   }
   // If the job type will be a batch job, ensure that a queue is specified
-  if ((!!job.jobType && job.jobType === Apps.JobTypeEnum.Batch) || (!job.jobType && app.jobType === Apps.JobTypeEnum.Batch)) {
+  if (
+    (!!job.jobType && job.jobType === Apps.JobTypeEnum.Batch) ||
+    (!job.jobType && app.jobType === Apps.JobTypeEnum.Batch)
+  ) {
     // Check to see if the job has a specified queue
     if (!job.execSystemLogicalQueue) {
       // If no queue exists, there must be a fallback to the app or system default
@@ -55,4 +65,4 @@ export const execSystemComplete = (job: Partial<Jobs.ReqSubmitJob>, app: Apps.Ta
     }
   }
   return true;
-}
+};

--- a/src/tapis-api/utils/jobExecSystem.ts
+++ b/src/tapis-api/utils/jobExecSystem.ts
@@ -1,27 +1,27 @@
 import { Apps, Jobs, Systems } from '@tapis/tapis-typescript';
 
 type DefaultSystem = {
-  source?: 'app'
-  systemId?: string
-}
+  source?: 'app';
+  systemId?: string;
+};
 
 /**
  * Computes the default execution system ID that will be used
- * 
+ *
  * @param app
- * @returns 
+ * @returns
  */
 export const computeDefaultSystem = (app: Apps.TapisApp): DefaultSystem => {
   if (app.jobAttributes?.execSystemId) {
     return {
       source: 'app',
-      systemId: app.jobAttributes?.execSystemId
-    }
+      systemId: app.jobAttributes?.execSystemId,
+    };
   }
   return {
     source: undefined,
-    systemId: undefined
-  }
+    systemId: undefined,
+  };
 };
 
 type DefaultQueue = {
@@ -32,11 +32,11 @@ type DefaultQueue = {
 /**
  * Computes the logical queue that will be used, if the job does not
  * specify one
- * 
+ *
  * @param job
- * @param app 
- * @param systems 
- * @returns 
+ * @param app
+ * @param systems
+ * @returns
  */
 export const computeDefaultQueue = (
   job: Partial<Jobs.ReqSubmitJob>,
@@ -53,23 +53,27 @@ export const computeDefaultQueue = (
 
   // If the job specifies a system, look for its default logical queue
   if (job.execSystemId) {
-    const selectedSystem = systems.find((system) => system.id === job.execSystemId);
+    const selectedSystem = systems.find(
+      (system) => system.id === job.execSystemId
+    );
     if (selectedSystem?.batchDefaultLogicalQueue) {
       return {
         source: 'system',
-        queue: selectedSystem.batchDefaultLogicalQueue
-      } 
+        queue: selectedSystem.batchDefaultLogicalQueue,
+      };
     }
   }
 
   // If the app specifies a system, look for its default logical queue
   if (app.jobAttributes?.execSystemId) {
-    const appSystem = systems.find((system) => system.id === app.jobAttributes?.execSystemId);
+    const appSystem = systems.find(
+      (system) => system.id === app.jobAttributes?.execSystemId
+    );
     if (appSystem?.batchDefaultLogicalQueue) {
       return {
         source: 'app system',
-        queue: appSystem.batchDefaultLogicalQueue
-      }
+        queue: appSystem.batchDefaultLogicalQueue,
+      };
     }
   }
 
@@ -81,55 +85,59 @@ export const computeDefaultQueue = (
 };
 
 type DefaultJobType = {
-  source: 'app' | 'app system' | 'system' | 'tapis',
-  jobType: Apps.JobTypeEnum
-}
+  source: 'app' | 'app system' | 'system' | 'tapis';
+  jobType: Apps.JobTypeEnum;
+};
 
 /**
  * Determines the default jobType if one is not specified in the jobType field in a job
  * using the algorithm specified at:
- * 
+ *
  * https://tapis.readthedocs.io/en/latest/technical/jobs.html#job-type
- * 
- * @param job 
- * @param app 
- * @param systems 
- * @returns 
+ *
+ * @param job
+ * @param app
+ * @param systems
+ * @returns
  */
 export const computeDefaultJobType = (
   job: Partial<Jobs.ReqSubmitJob>,
   app: Apps.TapisApp,
-  systems: Array<Systems.TapisSystem>,
+  systems: Array<Systems.TapisSystem>
 ): DefaultJobType => {
   if (app.jobType) {
     return {
       source: 'app',
-      jobType: app.jobType!
-    }
+      jobType: app.jobType!,
+    };
   }
   if (job?.execSystemId) {
-    const selectedSystem = systems.find(system => system.id === job.execSystemId);
+    const selectedSystem = systems.find(
+      (system) => system.id === job.execSystemId
+    );
     if (selectedSystem?.canRunBatch) {
       return {
         source: 'system',
-        jobType: Apps.JobTypeEnum.Batch
-      }
+        jobType: Apps.JobTypeEnum.Batch,
+      };
     }
   }
   if (app.jobAttributes?.execSystemId) {
-    const appSystem = systems.find(system => system.id === app.jobAttributes?.execSystemId);
+    const appSystem = systems.find(
+      (system) => system.id === app.jobAttributes?.execSystemId
+    );
     if (appSystem?.canRunBatch) {
       return {
         source: 'app system',
-        jobType: Apps.JobTypeEnum.Batch
-      }
+        jobType: Apps.JobTypeEnum.Batch,
+      };
     }
   }
   return {
     source: 'tapis',
-    jobType: Apps.JobTypeEnum.Fork
-  }
-}
+    jobType: Apps.JobTypeEnum.Fork,
+  };
+};
 
 export const execSystemComplete = (
   job: Partial<Jobs.ReqSubmitJob>,

--- a/src/tapis-api/utils/jobRequiredFields.ts
+++ b/src/tapis-api/utils/jobRequiredFields.ts
@@ -1,5 +1,5 @@
 import { Jobs } from '@tapis/tapis-typescript';
 
 export const jobRequiredFieldsComplete = (job: Partial<Jobs.ReqSubmitJob>) => {
-  return !!job.name && !!job.appId && !!job.appVersion && !!job.execSystemId;
+  return !!job.name && !!job.appId && !!job.appVersion;
 };

--- a/src/tapis-ui/_common/FieldWrapperFormik/fields/FormikSelect.tsx
+++ b/src/tapis-ui/_common/FieldWrapperFormik/fields/FormikSelect.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent } from 'react';
 import FieldWrapper from '../FieldWrapperFormik';
 import { Input } from 'reactstrap';
-import { FieldInputProps, useField, useFormikContext } from 'formik';
+import { FieldInputProps, useFormikContext } from 'formik';
 import { FormikInputProps } from '.';
 import { setFieldValue } from './formikPatch';
 
@@ -13,7 +13,7 @@ const FormikSelect: React.FC<React.PropsWithChildren<FormikInputProps>> = ({
   children,
   ...props
 }: FormikInputProps) => {
-  const formikContext  = useFormikContext();
+  const formikContext = useFormikContext();
   return (
     <FieldWrapper
       name={name}
@@ -26,7 +26,11 @@ const FormikSelect: React.FC<React.PropsWithChildren<FormikInputProps>> = ({
           // Use patched formik setFieldValue
           // An option with no children and value set to undefined will preduce an empty string as the target value
           // ex: <option value={undefined} label="Please select a value" />
-          setFieldValue(formikContext, name, event.target.value === '' ? undefined : event.target.value);
+          setFieldValue(
+            formikContext,
+            name,
+            event.target.value === '' ? undefined : event.target.value
+          );
         };
         return (
           <Input
@@ -41,7 +45,7 @@ const FormikSelect: React.FC<React.PropsWithChildren<FormikInputProps>> = ({
         );
       }}
     />
-  )
-}
+  );
+};
 
 export default FormikSelect;

--- a/src/tapis-ui/_common/FieldWrapperFormik/fields/FormikSelect.tsx
+++ b/src/tapis-ui/_common/FieldWrapperFormik/fields/FormikSelect.tsx
@@ -24,6 +24,8 @@ const FormikSelect: React.FC<React.PropsWithChildren<FormikInputProps>> = ({
         const { onChange: formikOnChange, ...otherFormikProps } = formikProps;
         const onChange = (event: ChangeEvent<HTMLInputElement>) => {
           // Use patched formik setFieldValue
+          // An option with no children and value set to undefined will preduce an empty string as the target value
+          // ex: <option value={undefined} label="Please select a value" />
           setFieldValue(formikContext, name, event.target.value === '' ? undefined : event.target.value);
         };
         return (

--- a/src/tapis-ui/_common/FieldWrapperFormik/fields/FormikSelect.tsx
+++ b/src/tapis-ui/_common/FieldWrapperFormik/fields/FormikSelect.tsx
@@ -1,8 +1,9 @@
 import { ChangeEvent } from 'react';
 import FieldWrapper from '../FieldWrapperFormik';
 import { Input } from 'reactstrap';
-import { FieldInputProps } from 'formik';
+import { FieldInputProps, useField, useFormikContext } from 'formik';
 import { FormikInputProps } from '.';
+import { setFieldValue } from './formikPatch';
 
 const FormikSelect: React.FC<React.PropsWithChildren<FormikInputProps>> = ({
   name,
@@ -11,32 +12,34 @@ const FormikSelect: React.FC<React.PropsWithChildren<FormikInputProps>> = ({
   description,
   children,
   ...props
-}: FormikInputProps) => (
-  <FieldWrapper
-    name={name}
-    label={label}
-    required={required}
-    description={description}
-    as={(formikProps: FieldInputProps<any>) => {
-      const { onChange: formikOnChange, ...otherFormikProps } = formikProps;
-      const { onChange: passedOnChange, ...otherProps } = props;
-      const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-        passedOnChange && passedOnChange(event);
-        formikOnChange && formikOnChange(event);
-      };
-      return (
-        <Input
-          bsSize="sm"
-          type="select"
-          onChange={onChange}
-          {...otherProps}
-          {...otherFormikProps}
-        >
-          {children}
-        </Input>
-      );
-    }}
-  />
-);
+}: FormikInputProps) => {
+  const formikContext  = useFormikContext();
+  return (
+    <FieldWrapper
+      name={name}
+      label={label}
+      required={required}
+      description={description}
+      as={(formikProps: FieldInputProps<any>) => {
+        const { onChange: formikOnChange, ...otherFormikProps } = formikProps;
+        const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+          // Use patched formik setFieldValue
+          setFieldValue(formikContext, name, event.target.value === '' ? undefined : event.target.value);
+        };
+        return (
+          <Input
+            bsSize="sm"
+            type="select"
+            onChange={onChange}
+            {...props}
+            {...otherFormikProps}
+          >
+            {children}
+          </Input>
+        );
+      }}
+    />
+  )
+}
 
 export default FormikSelect;

--- a/src/tapis-ui/_common/FieldWrapperFormik/fields/formikPatch.ts
+++ b/src/tapis-ui/_common/FieldWrapperFormik/fields/formikPatch.ts
@@ -1,0 +1,75 @@
+import { FormikContextType, getIn, isObject, isInteger } from 'formik';
+import _ from 'lodash';
+
+/**
+ * Adaptation of setFieldValue wrapper from https://github.com/jaredpalmer/formik/issues/2332#issuecomment-819571154
+ * 
+ * There is a bug in the setIn function of Formik that deletes form keys that have undefined values rather than
+ * setting the field value to undefined. This is inconsistent with other types of Formik behavior, such as
+ * empty text Inputs resulting in form keys with undefined values
+ * 
+ * @param formikContext 
+ * @param field 
+ * @param value 
+ * @param shouldValidate 
+ */
+export function setFieldValue(formikContext: FormikContextType<unknown>, field: string, value: any, shouldValidate?: boolean): void {
+  const { setValues, validateForm, validateOnChange, setFieldValue, values } = formikContext;
+  // Override default behavior by forcing undefined to be set on the state
+  if (value === undefined) {
+    const setInValues = setIn(values, field, undefined);
+    setValues(setInValues);
+
+    const willValidate = shouldValidate === undefined ? validateOnChange : shouldValidate;
+    if (willValidate) {
+      validateForm(setInValues);
+    }
+  } else {
+    // Use default behavior for normal values
+    setFieldValue(field, value, shouldValidate);
+  }
+}
+
+/**
+ * A copy of Formik's setIn function, except it assigns undefined instead of deleting the property if the value
+ * being set is undefined.
+ * https://github.com/jaredpalmer/formik/issues/2332
+ */
+function setIn(obj: any, path: string, value: any): any {
+  const res: any = _.clone(obj); // This keeps inheritance when obj is a class
+  let resVal: any = res;
+  let i = 0;
+  const pathArray = _.toPath(path);
+
+  for (; i < pathArray.length - 1; i++) {
+    const currentPath: string = pathArray[i];
+    const currentObj: any = getIn(obj, pathArray.slice(0, i + 1));
+
+    if (currentObj && (isObject(currentObj) || Array.isArray(currentObj))) {
+      resVal = resVal[currentPath] = _.clone(currentObj);
+    } else {
+      const nextPath: string = pathArray[i + 1];
+      resVal = resVal[currentPath]
+        = isInteger(nextPath) && Number(nextPath) >= 0 ? [] : {};
+    }
+  }
+
+  // Return original object if new value is the same as current
+  if ((i === 0 ? obj : resVal)[pathArray[i]] === value) {
+    return obj;
+  }
+
+  if (value === undefined) {
+    resVal[pathArray[i]] = undefined;
+  } else {
+    resVal[pathArray[i]] = value;
+  }
+
+  // If the path array has a single element, the loop did not run.
+  // Deleting on `resVal` had no effect in this scenario, so we delete on the result instead.
+  if (i === 0 && value === undefined) {
+    res[pathArray[i]] = undefined;
+  }
+
+  return res;
+}

--- a/src/tapis-ui/_common/FieldWrapperFormik/fields/formikPatch.ts
+++ b/src/tapis-ui/_common/FieldWrapperFormik/fields/formikPatch.ts
@@ -3,24 +3,31 @@ import _ from 'lodash';
 
 /**
  * Adaptation of setFieldValue wrapper from https://github.com/jaredpalmer/formik/issues/2332#issuecomment-819571154
- * 
+ *
  * There is a bug in the setIn function of Formik that deletes form keys that have undefined values rather than
  * setting the field value to undefined. This is inconsistent with other types of Formik behavior, such as
  * empty text Inputs resulting in form keys with undefined values
- * 
- * @param formikContext 
- * @param field 
- * @param value 
- * @param shouldValidate 
+ *
+ * @param formikContext
+ * @param field
+ * @param value
+ * @param shouldValidate
  */
-export function setFieldValue(formikContext: FormikContextType<unknown>, field: string, value: any, shouldValidate?: boolean): void {
-  const { setValues, validateForm, validateOnChange, setFieldValue, values } = formikContext;
+export function setFieldValue(
+  formikContext: FormikContextType<unknown>,
+  field: string,
+  value: any,
+  shouldValidate?: boolean
+): void {
+  const { setValues, validateForm, validateOnChange, setFieldValue, values } =
+    formikContext;
   // Override default behavior by forcing undefined to be set on the state
   if (value === undefined) {
     const setInValues = setIn(values, field, undefined);
     setValues(setInValues);
 
-    const willValidate = shouldValidate === undefined ? validateOnChange : shouldValidate;
+    const willValidate =
+      shouldValidate === undefined ? validateOnChange : shouldValidate;
     if (willValidate) {
       validateForm(setInValues);
     }
@@ -49,8 +56,8 @@ function setIn(obj: any, path: string, value: any): any {
       resVal = resVal[currentPath] = _.clone(currentObj);
     } else {
       const nextPath: string = pathArray[i + 1];
-      resVal = resVal[currentPath]
-        = isInteger(nextPath) && Number(nextPath) >= 0 ? [] : {};
+      resVal = resVal[currentPath] =
+        isInteger(nextPath) && Number(nextPath) >= 0 ? [] : {};
     }
   }
 

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
@@ -21,7 +21,6 @@ const JobLauncherWizardRender: React.FC = () => {
 
   const formSubmit = useCallback(
     (value: Partial<Jobs.ReqSubmitJob>) => {
-      console.log('Values', value);
       if (value.jobType === Apps.JobTypeEnum.Fork) {
         value.execSystemLogicalQueue = undefined;
       }

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
@@ -55,7 +55,7 @@ export const JobLauncherWizardRender: React.FC<{ jobSteps: Array<JobStep> }> =
           ...stepProps,
         };
       });
-    }, [app, job, systems]);
+    }, [app, job, systems, jobSteps]);
 
     return (
       <Wizard

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
@@ -9,6 +9,7 @@ import {
   useSchedulerProfiles,
 } from 'tapis-hooks/systems';
 import { useJobLauncher, JobLauncherProvider } from './components';
+import { JobStep } from '.';
 import jobSteps from './steps';
 
 type JobLauncherWizardProps = {
@@ -16,7 +17,7 @@ type JobLauncherWizardProps = {
   appVersion: string;
 };
 
-const JobLauncherWizardRender: React.FC = () => {
+export const JobLauncherWizardRender: React.FC<{ jobSteps: Array<JobStep> }> = ({ jobSteps }) => {
   const { add, job, app, systems } = useJobLauncher();
 
   const formSubmit = useCallback(
@@ -105,7 +106,7 @@ const JobLauncherWizard: React.FC<JobLauncherWizardProps> = ({
         <JobLauncherProvider
           value={{ app, systems, defaultValues, schedulerProfiles }}
         >
-          <JobLauncherWizardRender />
+          <JobLauncherWizardRender jobSteps={jobSteps} />
         </JobLauncherProvider>
       )}
     </QueryWrapper>

--- a/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/JobLauncherWizard.tsx
@@ -17,53 +17,54 @@ type JobLauncherWizardProps = {
   appVersion: string;
 };
 
-export const JobLauncherWizardRender: React.FC<{ jobSteps: Array<JobStep> }> = ({ jobSteps }) => {
-  const { add, job, app, systems } = useJobLauncher();
+export const JobLauncherWizardRender: React.FC<{ jobSteps: Array<JobStep> }> =
+  ({ jobSteps }) => {
+    const { add, job, app, systems } = useJobLauncher();
 
-  const formSubmit = useCallback(
-    (value: Partial<Jobs.ReqSubmitJob>) => {
-      if (value.jobType === Apps.JobTypeEnum.Fork) {
-        value.execSystemLogicalQueue = undefined;
-      }
-      if (value.isMpi) {
-        value.cmdPrefix = undefined;
-      } else {
-        value.mpiCmd = undefined;
-      }
-      if (value.parameterSet) {
-        value.parameterSet = {
-          ...job.parameterSet,
-          ...value.parameterSet,
+    const formSubmit = useCallback(
+      (value: Partial<Jobs.ReqSubmitJob>) => {
+        if (value.jobType === Apps.JobTypeEnum.Fork) {
+          value.execSystemLogicalQueue = undefined;
+        }
+        if (value.isMpi) {
+          value.cmdPrefix = undefined;
+        } else {
+          value.mpiCmd = undefined;
+        }
+        if (value.parameterSet) {
+          value.parameterSet = {
+            ...job.parameterSet,
+            ...value.parameterSet,
+          };
+        }
+        add(value);
+      },
+      [add, job]
+    );
+
+    // Map Array of JobSteps into an array of WizardSteps
+    const steps: Array<WizardStep<Jobs.ReqSubmitJob>> = useMemo(() => {
+      return jobSteps.map((jobStep) => {
+        const { generateInitialValues, validateThunk, ...stepProps } = jobStep;
+        return {
+          initialValues: generateInitialValues({ job, app, systems }),
+          // generate a validation function from the JobStep's validateThunk, given the current hook values
+          validate: validateThunk
+            ? validateThunk({ job, app, systems })
+            : undefined,
+          ...stepProps,
         };
-      }
-      add(value);
-    },
-    [add, job]
-  );
+      });
+    }, [app, job, systems]);
 
-  // Map Array of JobSteps into an array of WizardSteps
-  const steps: Array<WizardStep<Jobs.ReqSubmitJob>> = useMemo(() => {
-    return jobSteps.map((jobStep) => {
-      const { generateInitialValues, validateThunk, ...stepProps } = jobStep;
-      return {
-        initialValues: generateInitialValues({ job, app, systems }),
-        // generate a validation function from the JobStep's validateThunk, given the current hook values
-        validate: validateThunk
-          ? validateThunk({ job, app, systems })
-          : undefined,
-        ...stepProps,
-      };
-    });
-  }, [app, job, systems]);
-
-  return (
-    <Wizard
-      steps={steps}
-      memo={`${app.id}${app.version}`}
-      formSubmit={formSubmit}
-    />
-  );
-};
+    return (
+      <Wizard
+        steps={steps}
+        memo={`${app.id}${app.version}`}
+        formSubmit={formSubmit}
+      />
+    );
+  };
 
 const JobLauncherWizard: React.FC<JobLauncherWizardProps> = ({
   appId,

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.test.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.test.tsx
@@ -15,38 +15,46 @@ describe('ExecOptions step', () => {
     (useJobLauncher as jest.Mock).mockReturnValue({
       job: {},
       app: tapisApp,
-      systems: [ tapisSystem ]
+      systems: [tapisSystem],
     });
-    const { getAllByTestId } = renderComponent(<JobLauncherWizardRender jobSteps={[ ExecOptionsStep ]} />);
+    const { getAllByTestId } = renderComponent(
+      <JobLauncherWizardRender jobSteps={[ExecOptionsStep]} />
+    );
     await act(async () => {});
-    const execSystemId = getAllByTestId("execSystemId")[0];
+    const execSystemId = getAllByTestId('execSystemId')[0];
     expect(execSystemId).toHaveValue('');
   });
   it('Shows queue options if the job is a batch job', async () => {
     (useJobLauncher as jest.Mock).mockReturnValue({
       job: {},
       app: tapisApp,
-      systems: [ tapisSystem ]
+      systems: [tapisSystem],
     });
-    const { getAllByTestId } = renderComponent(<JobLauncherWizardRender jobSteps={[ ExecOptionsStep ]} />);
-    await act(async () => { });
-    const execSystemLogicalQueue = getAllByTestId("execSystemLogicalQueue")[0];
+    const { getAllByTestId } = renderComponent(
+      <JobLauncherWizardRender jobSteps={[ExecOptionsStep]} />
+    );
+    await act(async () => {});
+    const execSystemLogicalQueue = getAllByTestId('execSystemLogicalQueue')[0];
     expect(execSystemLogicalQueue).toBeDefined();
     expect(execSystemLogicalQueue).toHaveValue('');
   });
   it('Does not show systems that are not capable of batch jobs', async () => {
-    const tapisSystemNoQueues = JSON.parse(JSON.stringify(tapisSystem)) as Systems.TapisSystem;
+    const tapisSystemNoQueues = JSON.parse(
+      JSON.stringify(tapisSystem)
+    ) as Systems.TapisSystem;
     tapisSystemNoQueues.batchLogicalQueues = [];
-    tapisSystemNoQueues.id = "noqueues.execution";
+    tapisSystemNoQueues.id = 'noqueues.execution';
     (useJobLauncher as jest.Mock).mockReturnValue({
       job: {},
       app: tapisApp,
-      systems: [ tapisSystem, tapisSystemNoQueues ]
+      systems: [tapisSystem, tapisSystemNoQueues],
     });
-    const { getAllByTestId, getAllByLabelText } = renderComponent(<JobLauncherWizardRender jobSteps={[ ExecOptionsStep ]} />);
-    await act(async () => { });
+    const { getAllByTestId, getAllByLabelText } = renderComponent(
+      <JobLauncherWizardRender jobSteps={[ExecOptionsStep]} />
+    );
+    await act(async () => {});
     const execSystems = getAllByTestId(/execSystemId-/);
     expect(execSystems.length).toEqual(1);
-    expect(execSystems[0]).toHaveProperty("label", "testuser2.execution");
+    expect(execSystems[0]).toHaveProperty('label', 'testuser2.execution');
   });
 });

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.test.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.test.tsx
@@ -49,7 +49,7 @@ describe('ExecOptions step', () => {
       app: tapisApp,
       systems: [tapisSystem, tapisSystemNoQueues],
     });
-    const { getAllByTestId, getAllByLabelText } = renderComponent(
+    const { getAllByTestId } = renderComponent(
       <JobLauncherWizardRender jobSteps={[ExecOptionsStep]} />
     );
     await act(async () => {});

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -12,7 +12,7 @@ import { Collapse } from 'tapis-ui/_common';
 import {
   computeDefaultQueue,
   computeDefaultSystem,
-  computeDefaultJobType
+  computeDefaultJobType,
 } from 'tapis-api/utils/jobExecSystem';
 import { capitalize } from './utils';
 import * as Yup from 'yup';
@@ -36,40 +36,47 @@ const SystemSelector: React.FC = () => {
   const [selectableSystems, setSelectableSystems] =
     useState<Array<Systems.TapisSystem>>(systems);
 
-  const { computedDefaultSystem, computedDefaultQueue, computedDefaultJobType, isBatch, selectedSystem } = useMemo(
-    () => {
-      // Compute labels for when undefined values are selected for systems, queues or jobType
-      const { source: systemSource, systemId } = computeDefaultSystem(app);
-      const computedDefaultSystem = systemSource
-        ? `App default (${systemId})`
-        : 'Please select a system';
-      const { source: queueSource, queue } = computeDefaultQueue(
-        values as Partial<Jobs.ReqSubmitJob>,
-        app,
-        systems
-      );
-      const queueSourceName = queueSource ?? 'please select a system';
-      const computedDefaultQueue = `${capitalize(queueSourceName)} default (${queue})`;
-      const { source: jobTypeSource, jobType } = computeDefaultJobType(
-        values as Partial<Jobs.ReqSubmitJob>,
-        app,
-        systems
-      );
-      const computedDefaultJobType = `${capitalize(jobTypeSource)} default (${jobType})`;
-      const isBatch = (values as Jobs.ReqSubmitJob)?.jobType === Apps.JobTypeEnum.Batch || 
-        jobType === Apps.JobTypeEnum.Batch;
-      const selectedSystem = (values as Jobs.ReqSubmitJob)?.execSystemId;
-      return {
-        computedDefaultSystem,
-        computedDefaultQueue,
-        computedDefaultJobType,
-        isBatch,
-        selectedSystem
-      }
-    },
-    [ values, app, systems]
-
-  )
+  const {
+    computedDefaultSystem,
+    computedDefaultQueue,
+    computedDefaultJobType,
+    isBatch,
+    selectedSystem,
+  } = useMemo(() => {
+    // Compute labels for when undefined values are selected for systems, queues or jobType
+    const { source: systemSource, systemId } = computeDefaultSystem(app);
+    const computedDefaultSystem = systemSource
+      ? `App default (${systemId})`
+      : 'Please select a system';
+    const { source: queueSource, queue } = computeDefaultQueue(
+      values as Partial<Jobs.ReqSubmitJob>,
+      app,
+      systems
+    );
+    const queueSourceName = queueSource ?? 'please select a system';
+    const computedDefaultQueue = `${capitalize(
+      queueSourceName
+    )} default (${queue})`;
+    const { source: jobTypeSource, jobType } = computeDefaultJobType(
+      values as Partial<Jobs.ReqSubmitJob>,
+      app,
+      systems
+    );
+    const computedDefaultJobType = `${capitalize(
+      jobTypeSource
+    )} default (${jobType})`;
+    const isBatch =
+      (values as Jobs.ReqSubmitJob)?.jobType === Apps.JobTypeEnum.Batch ||
+      jobType === Apps.JobTypeEnum.Batch;
+    const selectedSystem = (values as Jobs.ReqSubmitJob)?.execSystemId;
+    return {
+      computedDefaultSystem,
+      computedDefaultQueue,
+      computedDefaultJobType,
+      isBatch,
+      selectedSystem,
+    };
+  }, [values, app, systems]);
 
   useEffect(() => {
     // Handle changes to selectable execSystems and execSystemLogicalQueues
@@ -85,7 +92,10 @@ const SystemSelector: React.FC = () => {
     if (!isBatch) {
       setFieldValue('execSystemLogicalQueue', undefined);
     }
-    const system = getSystem(validSystems, selectedSystem ?? app.jobAttributes?.execSystemId);
+    const system = getSystem(
+      validSystems,
+      selectedSystem ?? app.jobAttributes?.execSystemId
+    );
     const queues = getLogicalQueues(system);
     setQueues(queues);
     setFieldValue('execSystemLogicalQueue', undefined);
@@ -140,7 +150,7 @@ const SystemSelector: React.FC = () => {
         >
           <option value={undefined} label={computedDefaultQueue} />
           {queues.map((queue) => (
-            <option 
+            <option
               value={queue.name}
               key={`queue-select-${queue.name}`}
               label={queue.name}
@@ -290,20 +300,19 @@ export const ExecOptionsSummary: React.FC = () => {
   const { job, app, systems } = useJobLauncher();
   const { isMpi, mpiCmd, cmdPrefix } = job;
 
-  const { computedSystem, computedQueue, computedJobType } = useMemo(
-    () => {
-      const { execSystemLogicalQueue, execSystemId, jobType } = job;
-      const computedSystem = execSystemId ?? computeDefaultSystem(app)?.systemId;
-      const computedQueue = execSystemLogicalQueue ?? computeDefaultQueue(job, app, systems)?.queue;
-      const computedJobType = jobType ?? computeDefaultJobType(job, app, systems)?.jobType;
-      return {
-        computedSystem,
-        computedQueue,
-        computedJobType
-      }
-    },
-    [ job, app, systems ]
-  )
+  const { computedSystem, computedQueue, computedJobType } = useMemo(() => {
+    const { execSystemLogicalQueue, execSystemId, jobType } = job;
+    const computedSystem = execSystemId ?? computeDefaultSystem(app)?.systemId;
+    const computedQueue =
+      execSystemLogicalQueue ?? computeDefaultQueue(job, app, systems)?.queue;
+    const computedJobType =
+      jobType ?? computeDefaultJobType(job, app, systems)?.jobType;
+    return {
+      computedSystem,
+      computedQueue,
+      computedJobType,
+    };
+  }, [job, app, systems]);
 
   return (
     <div>

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -369,7 +369,7 @@ type QueueErrors = {
 
 const validateThunk = ({ app, systems }: JobLauncherProviderParams) => {
   return (values: Partial<Jobs.ReqSubmitJob>) => {
-    const { nodeCount, coresPerNode, memoryMB, maxMinutes, jobType } = values;
+    const { execSystemId, execSystemLogicalQueue, nodeCount, coresPerNode, memoryMB, maxMinutes, jobType } = values;
     const errors: QueueErrors = {};
 
     const validation = validateExecSystem(
@@ -406,17 +406,16 @@ const validateThunk = ({ app, systems }: JobLauncherProviderParams) => {
       return errors;
     }
 
-    const computedExecSystemId = computeDefaultSystem(app).systemId;
+    const computedExecSystem = computeDefaultSystem(app);
     const computedLogicalQueue = computeDefaultQueue(
       values as Partial<Jobs.ReqSubmitJob>,
       app,
       systems
-    )?.queue;
-    const queue = systems
-      .find((system) => system.id === computedExecSystemId)
-      ?.batchLogicalQueues?.find(
-        (queue) => queue.name === computedLogicalQueue
-      );
+    );
+    const selectedSystem = systems.find(system => system.id === (execSystemId ?? computedExecSystem.systemId));
+    const queue = selectedSystem?.batchLogicalQueues?.find(
+      (queue) => queue.name === (execSystemLogicalQueue ?? computedLogicalQueue?.queue)
+    );
     if (!queue) {
       errors.execSystemLogicalQueue = `The specified queue does not exist on the selected execution system`;
       return errors;

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -111,11 +111,12 @@ const SystemSelector: React.FC = () => {
         label="Execution System"
         required={true}
       >
-        <option value={undefined} />
+        <option value={undefined} label="(default)"/>
         {selectableSystems.map((system) => (
-          <option value={system.id} key={`execsystem-select-${system.id}`}>
-            {system.id}
-          </option>
+          <option 
+            value={system.id} key={`execsystem-select-${system.id}`}
+            label={system.id}
+          />
         ))}
       </FormikSelect>
       <FormikSelect
@@ -124,8 +125,8 @@ const SystemSelector: React.FC = () => {
         description="Jobs can either be Batch or Fork"
         required={true}
       >
-        <option value={Apps.JobTypeEnum.Batch}>Batch</option>
-        <option value={Apps.JobTypeEnum.Fork}>Fork</option>
+        <option value={Apps.JobTypeEnum.Batch} label="Batch"/>
+        <option value={Apps.JobTypeEnum.Fork} label="Fork"/>
       </FormikSelect>
       {isBatch && (
         <FormikSelect
@@ -134,7 +135,7 @@ const SystemSelector: React.FC = () => {
           label="Batch Logical Queue"
           required={false}
         >
-          <option value={undefined} />
+          <option value={''} label="(default)"/>
           {queues.map((queue) => (
             <option value={queue.name} key={`queue-select-${queue.name}`}>
               {queue.name}

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -36,13 +36,9 @@ const SystemSelector: React.FC = () => {
   const [selectableSystems, setSelectableSystems] =
     useState<Array<Systems.TapisSystem>>(systems);
 
-  const selectedSystem = useMemo(
-    () => (values as Jobs.ReqSubmitJob)?.execSystemId,
-    [values]
-  );
-
-  const { computedDefaultSystem, computedDefaultQueue, computedDefaultJobType, isBatch } = useMemo(
+  const { computedDefaultSystem, computedDefaultQueue, computedDefaultJobType, isBatch, selectedSystem } = useMemo(
     () => {
+      // Compute labels for when undefined values are selected for systems, queues or jobType
       const { source: systemSource, systemId } = computeDefaultSystem(app);
       const computedDefaultSystem = systemSource
         ? `App default (${systemId})`
@@ -62,11 +58,13 @@ const SystemSelector: React.FC = () => {
       const computedDefaultJobType = `${capitalize(jobTypeSource)} default (${jobType})`;
       const isBatch = (values as Jobs.ReqSubmitJob)?.jobType === Apps.JobTypeEnum.Batch || 
         jobType === Apps.JobTypeEnum.Batch;
+      const selectedSystem = (values as Jobs.ReqSubmitJob)?.execSystemId;
       return {
         computedDefaultSystem,
         computedDefaultQueue,
         computedDefaultJobType,
-        isBatch
+        isBatch,
+        selectedSystem
       }
     },
     [ values, app, systems]
@@ -74,6 +72,7 @@ const SystemSelector: React.FC = () => {
   )
 
   useEffect(() => {
+    // Handle changes to selectable execSystems and execSystemLogicalQueues
     const validSystems = isBatch
       ? systems.filter((system) => !!system.batchLogicalQueues?.length)
       : systems;

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -9,7 +9,10 @@ import {
 } from 'tapis-ui/_common/FieldWrapperFormik';
 import { useFormikContext } from 'formik';
 import { Collapse } from 'tapis-ui/_common';
-import { computeDefaultQueue, computeDefaultSystem } from 'tapis-api/utils/jobExecSystem';
+import {
+  computeDefaultQueue,
+  computeDefaultSystem,
+} from 'tapis-api/utils/jobExecSystem';
 import * as Yup from 'yup';
 import fieldArrayStyles from '../FieldArray.module.scss';
 import { JobStep, JobLauncherProviderParams } from '../';
@@ -74,24 +77,26 @@ const SystemSelector: React.FC = () => {
     [values]
   );
 
-  const computedDefaultSystem = useMemo(
-    () => {
-      const defaultSystem = computeDefaultSystem(app);
-      return defaultSystem ? `App default (${defaultSystem})` : 'Please select a system';
-    },
-    [ app ]
-  )
+  const computedDefaultSystem = useMemo(() => {
+    const defaultSystem = computeDefaultSystem(app);
+    return defaultSystem
+      ? `App default (${defaultSystem})`
+      : 'Please select a system';
+  }, [app]);
 
-  const computedDefaultQueue = useMemo(
-    () => {
-      const { source, queue } = computeDefaultQueue(values as Partial<Jobs.ReqSubmitJob>, app, systems);
-      if (!queue) {
-        return "Please select a queue"
-      }
-      return `${source!.charAt(0).toUpperCase() + source!.slice(1)} default (${queue})`
-    },
-    [ values, app, systems ]
-  )
+  const computedDefaultQueue = useMemo(() => {
+    const { source, queue } = computeDefaultQueue(
+      values as Partial<Jobs.ReqSubmitJob>,
+      app,
+      systems
+    );
+    if (!queue) {
+      return 'Please select a queue';
+    }
+    return `${
+      source!.charAt(0).toUpperCase() + source!.slice(1)
+    } default (${queue})`;
+  }, [values, app, systems]);
 
   useEffect(() => {
     const validSystems = isBatch
@@ -106,9 +111,6 @@ const SystemSelector: React.FC = () => {
     if (!isBatch) {
       setFieldValue('execSystemLogicalQueue', undefined);
     }
-    const logicalQueue = isBatch
-      ? getLogicalQueue(app, validSystems, selectedSystem)
-      : undefined;
     const system = getSystem(validSystems, selectedSystem);
     const queues = getLogicalQueues(system);
     setQueues(queues);
@@ -131,10 +133,11 @@ const SystemSelector: React.FC = () => {
         label="Execution System"
         required={true}
       >
-        <option value={''} label={computedDefaultSystem}/>
+        <option value={''} label={computedDefaultSystem} />
         {selectableSystems.map((system) => (
-          <option 
-            value={system.id} key={`execsystem-select-${system.id}`}
+          <option
+            value={system.id}
+            key={`execsystem-select-${system.id}`}
             label={system.id}
           />
         ))}
@@ -145,8 +148,8 @@ const SystemSelector: React.FC = () => {
         description="Jobs can either be Batch or Fork"
         required={true}
       >
-        <option value={Apps.JobTypeEnum.Batch} label="Batch"/>
-        <option value={Apps.JobTypeEnum.Fork} label="Fork"/>
+        <option value={Apps.JobTypeEnum.Batch} label="Batch" />
+        <option value={Apps.JobTypeEnum.Fork} label="Fork" />
       </FormikSelect>
       {isBatch && (
         <FormikSelect
@@ -308,18 +311,15 @@ export const ExecOptionsSummary: React.FC = () => {
   const computedSystem = execSystemId ?? computeDefaultSystem(app);
   const { queue: defaultQueue } = computeDefaultQueue(job, app, systems);
   const computedQueue = execSystemLogicalQueue ?? defaultQueue;
-  const isBatch = useMemo(
-    () => {
-      if (job.jobType === Apps.JobTypeEnum.Batch) {
-        return true;
-      }
-      if (app.jobType == Apps.JobTypeEnum.Batch) {
-        return true;
-      }
-      return false;
-    },
-    [ job, app ]
-  )
+  const isBatch = useMemo(() => {
+    if (job.jobType === Apps.JobTypeEnum.Batch) {
+      return true;
+    }
+    if (app.jobType === Apps.JobTypeEnum.Batch) {
+      return true;
+    }
+    return false;
+  }, [job, app]);
   return (
     <div>
       <StepSummaryField
@@ -460,9 +460,7 @@ const generateInitialValues = ({
   systems,
 }: JobLauncherProviderParams): Partial<Jobs.ReqSubmitJob> => ({
   execSystemId: job.execSystemId,
-  execSystemLogicalQueue: job.execSystemId
-    ? getLogicalQueue(app, systems, job.execSystemId)
-    : undefined,
+  execSystemLogicalQueue: job.execSystemLogicalQueue,
   jobType: job.jobType,
   execSystemExecDir: job.execSystemExecDir,
   execSystemInputDir: job.execSystemInputDir,

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/ExecOptions.tsx
@@ -133,7 +133,7 @@ const SystemSelector: React.FC = () => {
         label="Execution System"
         required={true}
       >
-        <option value={''} label={computedDefaultSystem} />
+        <option value={undefined} label={computedDefaultSystem} />
         {selectableSystems.map((system) => (
           <option
             value={system.id}
@@ -158,7 +158,7 @@ const SystemSelector: React.FC = () => {
           label="Batch Logical Queue"
           required={false}
         >
-          <option value={''} label={computedDefaultQueue} />
+          <option value={undefined} label={computedDefaultQueue} />
           {queues.map((queue) => (
             <option value={queue.name} key={`queue-select-${queue.name}`}>
               {queue.name}

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/JobSubmit.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/JobSubmit.tsx
@@ -4,6 +4,7 @@ import { JSONDisplay } from 'tapis-ui/_common';
 import { fileInputsComplete } from 'tapis-api/utils/jobFileInputs';
 import { fileInputArraysComplete } from 'tapis-api/utils/jobFileInputArrays';
 import { jobRequiredFieldsComplete } from 'tapis-api/utils/jobRequiredFields';
+import { execSystemComplete } from 'tapis-api/utils/jobExecSystem';
 import { StepSummaryField } from '../components';
 import { SubmitWrapper } from 'tapis-ui/_wrappers';
 import { Jobs } from '@tapis/tapis-typescript';
@@ -13,8 +14,9 @@ import { Button } from 'reactstrap';
 import arrayStyles from '../FieldArray.module.scss';
 
 export const JobSubmit: React.FC = () => {
-  const { job, app } = useJobLauncher();
+  const { job, app, systems } = useJobLauncher();
   const isComplete =
+    execSystemComplete(job, app, systems) &&
     jobRequiredFieldsComplete(job) &&
     fileInputsComplete(app, job.fileInputs ?? []) &&
     fileInputArraysComplete(app, job.fileInputArrays ?? []);
@@ -64,8 +66,9 @@ export const JobSubmit: React.FC = () => {
 };
 
 export const JobSubmitSummary: React.FC = () => {
-  const { app, job } = useJobLauncher();
+  const { app, job, systems } = useJobLauncher();
   const isComplete =
+    execSystemComplete(job, app, systems) &&
     jobRequiredFieldsComplete(job) &&
     fileInputsComplete(app, job.fileInputs ?? []) &&
     fileInputArraysComplete(app, job.fileInputArrays ?? []);

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/JobSubmit.tsx
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/JobSubmit.tsx
@@ -4,7 +4,10 @@ import { JSONDisplay } from 'tapis-ui/_common';
 import { fileInputsComplete } from 'tapis-api/utils/jobFileInputs';
 import { fileInputArraysComplete } from 'tapis-api/utils/jobFileInputArrays';
 import { jobRequiredFieldsComplete } from 'tapis-api/utils/jobRequiredFields';
-import { execSystemComplete } from 'tapis-api/utils/jobExecSystem';
+import {
+  validateExecSystem,
+  ValidateExecSystemResult,
+} from 'tapis-api/utils/jobExecSystem';
 import { StepSummaryField } from '../components';
 import { SubmitWrapper } from 'tapis-ui/_wrappers';
 import { Jobs } from '@tapis/tapis-typescript';
@@ -16,7 +19,8 @@ import arrayStyles from '../FieldArray.module.scss';
 export const JobSubmit: React.FC = () => {
   const { job, app, systems } = useJobLauncher();
   const isComplete =
-    execSystemComplete(job, app, systems) &&
+    validateExecSystem(job, app, systems) ===
+      ValidateExecSystemResult.Complete &&
     jobRequiredFieldsComplete(job) &&
     fileInputsComplete(app, job.fileInputs ?? []) &&
     fileInputArraysComplete(app, job.fileInputArrays ?? []);
@@ -68,7 +72,7 @@ export const JobSubmit: React.FC = () => {
 export const JobSubmitSummary: React.FC = () => {
   const { app, job, systems } = useJobLauncher();
   const isComplete =
-    execSystemComplete(job, app, systems) &&
+    validateExecSystem(job, app, systems) &&
     jobRequiredFieldsComplete(job) &&
     fileInputsComplete(app, job.fileInputs ?? []) &&
     fileInputArraysComplete(app, job.fileInputArrays ?? []);

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/utils.ts
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/utils.ts
@@ -3,6 +3,10 @@ export const upperCaseFirstLetter = (str: string) => {
   return `${lower.slice(0, 1).toUpperCase()}${lower.slice(1)}`;
 };
 
+export const capitalize = (str: string) => {
+  return str!.charAt(0).toUpperCase() + str!.slice(1)
+}
+
 export const reduceRecord = (record: Record<'id', string>) => {
   const { id, ...contents } = record;
   return Object.values(contents).reduce(

--- a/src/tapis-ui/components/jobs/JobLauncher/steps/utils.ts
+++ b/src/tapis-ui/components/jobs/JobLauncher/steps/utils.ts
@@ -4,8 +4,8 @@ export const upperCaseFirstLetter = (str: string) => {
 };
 
 export const capitalize = (str: string) => {
-  return str!.charAt(0).toUpperCase() + str!.slice(1)
-}
+  return str!.charAt(0).toUpperCase() + str!.slice(1);
+};
 
 export const reduceRecord = (record: Record<'id', string>) => {
   const { id, ...contents } = record;


### PR DESCRIPTION
## Overview:

Allow undefined values for exec system and exec system logical queue, so that app or system defaults can be used

## Related Github Issues:

- [TUI-314](https://github.com/tapis-project/tapis-ui/issues/314)

## Summary of Changes:

- Add formikPatch that allows setting values in to undefined in FormikSelect
- Allow undefined defaults for execSystemId and execSystemLogicalQueue, so that they will fall back to the app specified exec system
- Add utility functions for computing exec system and queue defaults

## Testing Steps:

1. Test with both bsf v1 and NoExecSystem apps
2. Try using undefined defaults and seeing if the jobs can be submitted with undefined values
3. Try switching back and forth between fork and batch jobs (if the job is switched to batch and the previously selected system has no queues, the value should return to being undefined)

## UI Photos:

![image](https://user-images.githubusercontent.com/17181582/168893041-89b114d0-3db7-41ab-90ce-61d497abc2be.png)

## Notes:

If approved, please merge down to https://github.com/tapis-project/tapis-ui/pull/315 and approve there as well. (This is a fork of that PR)