### PR TITLE
updated tapis-typescript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/react-fontawesome": "^0.1.8",
         "@material-ui/core": "^4.12.3",
         "@reduxjs/toolkit": "^1.5.1",
-        "@tapis/tapis-typescript": "^0.0.26",
+        "@tapis/tapis-typescript": "^0.0.27",
         "@uiw/react-codemirror": "^4.19.7",
         "@uiw/react-textarea-code-editor": "^2.0.6",
         "axios": "^0.21.4",
@@ -3762,15 +3762,16 @@
       }
     },
     "node_modules/@tapis/tapis-typescript": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript/-/tapis-typescript-0.0.26.tgz",
-      "integrity": "sha512-22gPzNsJAM8/ZJuxbBRrWoqh1BBSyy+Hr73QG1v82nHs1VXcevANmwdkUxx9ZWf+rSm70wm0Pk1bDfa1/C7+dQ==",
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript/-/tapis-typescript-0.0.27.tgz",
+      "integrity": "sha512-EAAkaGlzgzcgpQImcMb0HzCHeG6Hbeh6kBBv0syVDoPy0tZDZH0XsjMn57SX7QbatwzMKWzVWFgL2A/gHAtjaw==",
       "dependencies": {
         "@tapis/tapis-typescript-actors": "^0.0.3",
         "@tapis/tapis-typescript-apps": "^0.0.8",
         "@tapis/tapis-typescript-authenticator": "^0.0.2",
         "@tapis/tapis-typescript-files": "^0.0.3",
         "@tapis/tapis-typescript-jobs": "^0.0.4",
+        "@tapis/tapis-typescript-mlhub-models": "^0.0.1",
         "@tapis/tapis-typescript-pods": "^0.0.2",
         "@tapis/tapis-typescript-streams": "^0.0.4",
         "@tapis/tapis-typescript-systems": "^0.0.3",
@@ -3804,6 +3805,11 @@
       "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript-jobs/-/tapis-typescript-jobs-0.0.4.tgz",
       "integrity": "sha512-3HPgRd1OvkfDKSNecGPGcCn9PcfUYB0XMasLR65BXwrjxM8CKDJ/nru30hUspkjQ5RahfL7LDO47wnCjCbt2Cw=="
     },
+    "node_modules/@tapis/tapis-typescript-mlhub-models": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript-mlhub-models/-/tapis-typescript-mlhub-models-0.0.1.tgz",
+      "integrity": "sha512-lsenNcQ+PVPazNYx5csNEUu/GFffnNkmncb1cQlUNl2dN4CTwaXfKSuWQPYxosds8OO71foAsK8cNhR//yhDlw=="
+    },
     "node_modules/@tapis/tapis-typescript-pods": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript-pods/-/tapis-typescript-pods-0.0.2.tgz",
@@ -3828,6 +3834,167 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript-workflows/-/tapis-typescript-workflows-0.0.8.tgz",
       "integrity": "sha512-+WXWIo42VlAS8jyPTjgMiAJK1lGjqkCepoZBydUtmUkd8xgyQaOqkNJtGhwfyTpAT09F6idYcxnVwSQn5Il+9A=="
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.0.0.tgz",
+      "integrity": "sha512-PmJPnogldqoVFf+EwbHvbBJ98MmqASV8kLrBYgsDNxQcFMeIS7JFL48sfyXvuMtgmWO/wMhh25odr+8VhDmn4g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/@babel/runtime": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@testing-library/dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@testing-library/dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.14.1",
@@ -9241,6 +9408,16 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/des.js": {
@@ -15712,6 +15889,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
     },
     "node_modules/js-base64": {
       "version": "2.6.4",
@@ -28723,15 +28906,16 @@
       }
     },
     "@tapis/tapis-typescript": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript/-/tapis-typescript-0.0.26.tgz",
-      "integrity": "sha512-22gPzNsJAM8/ZJuxbBRrWoqh1BBSyy+Hr73QG1v82nHs1VXcevANmwdkUxx9ZWf+rSm70wm0Pk1bDfa1/C7+dQ==",
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript/-/tapis-typescript-0.0.27.tgz",
+      "integrity": "sha512-EAAkaGlzgzcgpQImcMb0HzCHeG6Hbeh6kBBv0syVDoPy0tZDZH0XsjMn57SX7QbatwzMKWzVWFgL2A/gHAtjaw==",
       "requires": {
         "@tapis/tapis-typescript-actors": "^0.0.3",
         "@tapis/tapis-typescript-apps": "^0.0.8",
         "@tapis/tapis-typescript-authenticator": "^0.0.2",
         "@tapis/tapis-typescript-files": "^0.0.3",
         "@tapis/tapis-typescript-jobs": "^0.0.4",
+        "@tapis/tapis-typescript-mlhub-models": "^0.0.1",
         "@tapis/tapis-typescript-pods": "^0.0.2",
         "@tapis/tapis-typescript-streams": "^0.0.4",
         "@tapis/tapis-typescript-systems": "^0.0.3",
@@ -28765,6 +28949,11 @@
       "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript-jobs/-/tapis-typescript-jobs-0.0.4.tgz",
       "integrity": "sha512-3HPgRd1OvkfDKSNecGPGcCn9PcfUYB0XMasLR65BXwrjxM8CKDJ/nru30hUspkjQ5RahfL7LDO47wnCjCbt2Cw=="
     },
+    "@tapis/tapis-typescript-mlhub-models": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript-mlhub-models/-/tapis-typescript-mlhub-models-0.0.1.tgz",
+      "integrity": "sha512-lsenNcQ+PVPazNYx5csNEUu/GFffnNkmncb1cQlUNl2dN4CTwaXfKSuWQPYxosds8OO71foAsK8cNhR//yhDlw=="
+    },
     "@tapis/tapis-typescript-pods": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript-pods/-/tapis-typescript-pods-0.0.2.tgz",
@@ -28789,6 +28978,135 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@tapis/tapis-typescript-workflows/-/tapis-typescript-workflows-0.0.8.tgz",
       "integrity": "sha512-+WXWIo42VlAS8jyPTjgMiAJK1lGjqkCepoZBydUtmUkd8xgyQaOqkNJtGhwfyTpAT09F6idYcxnVwSQn5Il+9A=="
+    },
+    "@testing-library/dom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.0.0.tgz",
+      "integrity": "sha512-PmJPnogldqoVFf+EwbHvbBJ98MmqASV8kLrBYgsDNxQcFMeIS7JFL48sfyXvuMtgmWO/wMhh25odr+8VhDmn4g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.24.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+          "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "regenerator-runtime": "^0.14.0"
+          }
+        },
+        "@types/aria-query": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+          "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+          "dev": true,
+          "peer": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aria-query": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "dequal": "^2.0.3"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "peer": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "peer": true
+        },
+        "pretty-format": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true,
+              "peer": true
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+          "dev": true,
+          "peer": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "@testing-library/jest-dom": {
       "version": "5.14.1",
@@ -33141,6 +33459,13 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "peer": true
     },
     "des.js": {
       "version": "1.0.1",
@@ -37967,6 +38292,12 @@
           }
         }
       }
+    },
+    "jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
     },
     "js-base64": {
       "version": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@material-ui/core": "^4.12.3",
     "@reduxjs/toolkit": "^1.5.1",
-    "@tapis/tapis-typescript": "^0.0.26",
+    "@tapis/tapis-typescript": "^0.0.27",
     "@uiw/react-codemirror": "^4.19.7",
     "@uiw/react-textarea-code-editor": "^2.0.6",
     "axios": "^0.21.4",


### PR DESCRIPTION
## Overview:

## Related Github Issues:

- [TUI-359](https://github.com/tapis-project/tapis-ui/issues/359)

## Summary of Changes:
- update `tapis-typescript` version to `0.0.27` to include  ML Hub models api

## Testing Steps:

1.

## UI Photos:

## Notes:
