### PR TITLE
Pods - Start/Restart/Stop/Logs/ActionLogs/Hints/Pretty Tabs/AutoPodID…

### DIFF
--- a/src/tapis-api/pods/index.ts
+++ b/src/tapis-api/pods/index.ts
@@ -1,4 +1,8 @@
 export { default as list } from './list';
+export { default as logs } from './logs';
 export { default as details } from './details';
 export { default as makeNewPod } from './makeNewPod';
 export { default as deletePod } from './deletePod';
+export { default as startPod } from './startPod';
+export { default as restartPod } from './restartPod';
+export { default as stopPod } from './stopPod';

--- a/src/tapis-api/pods/logs.ts
+++ b/src/tapis-api/pods/logs.ts
@@ -1,0 +1,18 @@
+import { Pods } from '@tapis/tapis-typescript';
+import { apiGenerator, errorDecoder } from 'tapis-api/utils';
+
+const logs = (
+  params: Pods.GetPodLogsRequest,
+  basePath: string,
+  jwt: string
+) => {
+  const api: Pods.LogsApi = apiGenerator<Pods.LogsApi>(
+    Pods,
+    Pods.LogsApi,
+    basePath,
+    jwt
+  );
+  return errorDecoder<Pods.PodLogsResponse>(() => api.getPodLogs(params));
+};
+
+export default logs;

--- a/src/tapis-api/pods/restartPod.ts
+++ b/src/tapis-api/pods/restartPod.ts
@@ -1,0 +1,14 @@
+import { Pods } from '@tapis/tapis-typescript';
+import { apiGenerator, errorDecoder } from 'tapis-api/utils';
+
+const restartPod = (podId: string, basePath: string, jwt: string) => {
+  const api: Pods.PodsApi = apiGenerator<Pods.PodsApi>(
+    Pods,
+    Pods.PodsApi,
+    basePath,
+    jwt
+  );
+  return errorDecoder<Pods.PodResponse>(() => api.restartPod({ podId }));
+};
+
+export default restartPod;

--- a/src/tapis-api/pods/startPod.ts
+++ b/src/tapis-api/pods/startPod.ts
@@ -1,0 +1,14 @@
+import { Pods } from '@tapis/tapis-typescript';
+import { apiGenerator, errorDecoder } from 'tapis-api/utils';
+
+const startPod = (podId: string, basePath: string, jwt: string) => {
+  const api: Pods.PodsApi = apiGenerator<Pods.PodsApi>(
+    Pods,
+    Pods.PodsApi,
+    basePath,
+    jwt
+  );
+  return errorDecoder<Pods.PodResponse>(() => api.startPod({ podId }));
+};
+
+export default startPod;

--- a/src/tapis-api/pods/stopPod.ts
+++ b/src/tapis-api/pods/stopPod.ts
@@ -1,0 +1,14 @@
+import { Pods } from '@tapis/tapis-typescript';
+import { apiGenerator, errorDecoder } from 'tapis-api/utils';
+
+const stopPod = (podId: string, basePath: string, jwt: string) => {
+  const api: Pods.PodsApi = apiGenerator<Pods.PodsApi>(
+    Pods,
+    Pods.PodsApi,
+    basePath,
+    jwt
+  );
+  return errorDecoder<Pods.PodResponse>(() => api.stopPod({ podId }));
+};
+
+export default stopPod;

--- a/src/tapis-app/Login/_components/Login/Login.tsx
+++ b/src/tapis-app/Login/_components/Login/Login.tsx
@@ -57,6 +57,7 @@ const Login: React.FC = () => {
           <Button
             type="submit"
             className="btn btn-primary"
+            style={{ width: '5.5em' }} //explicitly set width otherwise button forces text overflow on press.
             disabled={isLoading || accessToken != null}
           >
             Log In

--- a/src/tapis-app/Pods/PodDetail/_Layout/Layout.tsx
+++ b/src/tapis-app/Pods/PodDetail/_Layout/Layout.tsx
@@ -1,8 +1,14 @@
 import { PodDetail } from 'tapis-ui/components/pods';
+import { PodFunctionBar } from 'tapis-app/Pods/_components';
 import { PageLayout, LayoutHeader } from 'tapis-ui/_common';
 
 const Layout: React.FC<{ podId: string }> = ({ podId }) => {
-  const header = <LayoutHeader type={'sub-header'}>Pod Details</LayoutHeader>;
+  const header = (
+    <LayoutHeader type={'sub-header'}>
+      Pod Details
+      <PodFunctionBar />
+    </LayoutHeader>
+  );
 
   const body = (
     <div style={{ flex: 1 }}>

--- a/src/tapis-app/Pods/_components/PodFunctionBar/PodFunctionBar.module.scss
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/PodFunctionBar.module.scss
@@ -1,0 +1,24 @@
+.toolbar-wrapper {
+  padding: 0;
+  margin: 0;
+  margin-top: 0.5em;
+  display: flex !important;
+}
+
+.btn {
+  font-weight: bold !important;
+}
+
+.toolbar-btn {
+  height: 2rem;
+  align-items: center;
+  margin-left: 0.5em;
+  font-size: 0.7em !important;
+  border-radius: 0 !important;
+  background-color: #f4f4f4 !important;
+  color: #333333 !important;
+}
+
+.toolbar-btn:disabled {
+  color: #999999 !important;
+}

--- a/src/tapis-app/Pods/_components/PodFunctionBar/PodFunctionBar.tsx
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/PodFunctionBar.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { Button } from 'reactstrap';
+import { Icon } from 'tapis-ui/_common';
+import styles from './PodFunctionBar.module.scss';
+import { useLocation } from 'react-router-dom';
+import StartPodModal from './StartPodModal';
+import RestartPodModal from './RestartPodModal';
+import StopPodModal from './StopPodModal';
+
+type ToolbarButtonProps = {
+  text: string;
+  icon: string;
+  onClick: () => void;
+  disabled: boolean;
+  color?: string;
+};
+
+export type ToolbarModalProps = {
+  toggle: () => void;
+};
+
+export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
+  text,
+  icon,
+  onClick,
+  color,
+  disabled = true,
+  ...rest
+}) => {
+  return (
+    <div>
+      <Button
+        disabled={disabled}
+        onClick={onClick}
+        className={styles['toolbar-btn']}
+        {...rest}
+      >
+        {icon && <Icon name={icon}></Icon>}
+        <span> {text}</span>
+      </Button>
+    </div>
+  );
+};
+
+const PodFunctionBar: React.FC = () => {
+  const [modal, setModal] = useState<string | undefined>(undefined);
+  const { pathname } = useLocation();
+
+  const toggle = () => {
+    setModal(undefined);
+  };
+
+  return (
+    <div id="file-operation-toolbar">
+      {pathname && (
+        <div className={styles['toolbar-wrapper']}>
+          <ToolbarButton
+            text="Start"
+            icon=""
+            color="primary"
+            disabled={false}
+            onClick={() => setModal('startpod')}
+            aria-label="startpod"
+          />
+          <ToolbarButton
+            text="Restart"
+            icon=""
+            disabled={false}
+            onClick={() => setModal('restartpod')}
+            aria-label="restartpod"
+          />
+          <ToolbarButton
+            text="Stop"
+            icon=""
+            disabled={false}
+            onClick={() => setModal('stoppod')}
+            aria-label="stoppod"
+          />
+
+          {modal === 'startpod' && <StartPodModal toggle={toggle} />}
+          {modal === 'restartpod' && <RestartPodModal toggle={toggle} />}
+          {modal === 'stoppod' && <StopPodModal toggle={toggle} />}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PodFunctionBar;

--- a/src/tapis-app/Pods/_components/PodFunctionBar/RestartPodModal/RestartPodModal.module.scss
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/RestartPodModal/RestartPodModal.module.scss
@@ -1,0 +1,16 @@
+.modal-settings {
+  max-height: 38rem;
+  overflow-y: scroll;
+}
+
+.item {
+  border: 1px dotted lightgray;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-bottom: 1em;
+}
+
+.array {
+  border: 1px solid gray;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-bottom: 0.5em;
+}

--- a/src/tapis-app/Pods/_components/PodFunctionBar/RestartPodModal/RestartPodModal.tsx
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/RestartPodModal/RestartPodModal.tsx
@@ -2,19 +2,19 @@ import { Button } from 'reactstrap';
 import { Pods } from '@tapis/tapis-typescript';
 import { GenericModal } from 'tapis-ui/_common';
 import { SubmitWrapper } from 'tapis-ui/_wrappers';
-import { ToolbarModalProps } from '../PodToolbar';
+import { ToolbarModalProps } from '../PodFunctionBar';
 import { Form, Formik } from 'formik';
 import { FormikSelect } from 'tapis-ui/_common/FieldWrapperFormik';
-import { useDeletePod, useList } from 'tapis-hooks/pods';
+import { useRestartPod, useList } from 'tapis-hooks/pods';
 import { useEffect, useCallback } from 'react';
-import styles from './DeletePodModal.module.scss';
+import styles from './RestartPodModal.module.scss';
 import * as Yup from 'yup';
 import { useQueryClient } from 'react-query';
 import { default as queryKeys } from 'tapis-hooks/pods/queryKeys';
 import { useTapisConfig } from 'tapis-hooks';
 import { useLocation } from 'react-router-dom';
 
-const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
+const RestartPodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   const { claims } = useTapisConfig();
   const effectiveUserId = claims['sub'].substring(
     0,
@@ -29,14 +29,14 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
     queryClient.invalidateQueries(queryKeys.list);
   }, [queryClient]);
 
-  const { deletePod, isLoading, error, isSuccess, reset } = useDeletePod();
+  const { restartPod, isLoading, error, isSuccess, reset } = useRestartPod();
 
   useEffect(() => {
     reset();
   }, [reset]);
 
   const validationSchema = Yup.object({
-    podId: Yup.string(),
+    podId: Yup.string().required('Select which pod to restart'),
   });
 
   const podId = useLocation().pathname.split('/')[2];
@@ -46,13 +46,13 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   };
 
   const onSubmit = ({ podId }: { podId: string }) => {
-    deletePod(podId, { onSuccess });
+    restartPod(podId, { onSuccess });
   };
 
   return (
     <GenericModal
       toggle={toggle}
-      title="Delete Pod"
+      title="Restart Pod"
       backdrop={true}
       body={
         <div className={styles['modal-settings']}>
@@ -71,11 +71,11 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
                   data-testid="podId"
                 >
                   <option disabled value={''}>
-                    Select a pod to delete
+                    Select a pod to restart
                   </option>
                   {pods.length ? (
                     pods.map((pod) => {
-                      return <option key={pod.pod_id}>{pod.pod_id}</option>;
+                      return <option>{pod.pod_id}</option>;
                     })
                   ) : (
                     <i>No pods found</i>
@@ -91,7 +91,7 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
           className={styles['modal-footer']}
           isLoading={isLoading}
           error={error}
-          success={isSuccess ? `Successfully deleted a pod` : ''}
+          success={isSuccess ? `Successfully restarted a pod` : ''}
           reverse={true}
         >
           <Button
@@ -101,7 +101,7 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
             aria-label="Submit"
             type="submit"
           >
-            Delete pod
+            Restart pod
           </Button>
         </SubmitWrapper>
       }
@@ -109,4 +109,4 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   );
 };
 
-export default DeletePodModal;
+export default RestartPodModal;

--- a/src/tapis-app/Pods/_components/PodFunctionBar/RestartPodModal/index.ts
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/RestartPodModal/index.ts
@@ -1,0 +1,3 @@
+import RestartPodModal from './RestartPodModal';
+
+export default RestartPodModal;

--- a/src/tapis-app/Pods/_components/PodFunctionBar/StartPodModal/StartPodModal.module.scss
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/StartPodModal/StartPodModal.module.scss
@@ -1,0 +1,16 @@
+.modal-settings {
+  max-height: 38rem;
+  overflow-y: scroll;
+}
+
+.item {
+  border: 1px dotted lightgray;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-bottom: 1em;
+}
+
+.array {
+  border: 1px solid gray;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-bottom: 0.5em;
+}

--- a/src/tapis-app/Pods/_components/PodFunctionBar/StartPodModal/StartPodModal.tsx
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/StartPodModal/StartPodModal.tsx
@@ -2,19 +2,19 @@ import { Button } from 'reactstrap';
 import { Pods } from '@tapis/tapis-typescript';
 import { GenericModal } from 'tapis-ui/_common';
 import { SubmitWrapper } from 'tapis-ui/_wrappers';
-import { ToolbarModalProps } from '../PodToolbar';
+import { ToolbarModalProps } from '../PodFunctionBar';
 import { Form, Formik } from 'formik';
 import { FormikSelect } from 'tapis-ui/_common/FieldWrapperFormik';
-import { useDeletePod, useList } from 'tapis-hooks/pods';
+import { useStartPod, useList } from 'tapis-hooks/pods';
 import { useEffect, useCallback } from 'react';
-import styles from './DeletePodModal.module.scss';
+import styles from './StartPodModal.module.scss';
 import * as Yup from 'yup';
 import { useQueryClient } from 'react-query';
 import { default as queryKeys } from 'tapis-hooks/pods/queryKeys';
 import { useTapisConfig } from 'tapis-hooks';
 import { useLocation } from 'react-router-dom';
 
-const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
+const StartPodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   const { claims } = useTapisConfig();
   const effectiveUserId = claims['sub'].substring(
     0,
@@ -29,14 +29,14 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
     queryClient.invalidateQueries(queryKeys.list);
   }, [queryClient]);
 
-  const { deletePod, isLoading, error, isSuccess, reset } = useDeletePod();
+  const { startPod, isLoading, error, isSuccess, reset } = useStartPod();
 
   useEffect(() => {
     reset();
   }, [reset]);
 
   const validationSchema = Yup.object({
-    podId: Yup.string(),
+    podId: Yup.string().required('Required'),
   });
 
   const podId = useLocation().pathname.split('/')[2];
@@ -46,13 +46,13 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   };
 
   const onSubmit = ({ podId }: { podId: string }) => {
-    deletePod(podId, { onSuccess });
+    startPod(podId, { onSuccess });
   };
 
   return (
     <GenericModal
       toggle={toggle}
-      title="Delete Pod"
+      title="Start Pod"
       backdrop={true}
       body={
         <div className={styles['modal-settings']}>
@@ -71,11 +71,11 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
                   data-testid="podId"
                 >
                   <option disabled value={''}>
-                    Select a pod to delete
+                    Select a pod to start
                   </option>
                   {pods.length ? (
                     pods.map((pod) => {
-                      return <option key={pod.pod_id}>{pod.pod_id}</option>;
+                      return <option>{pod.pod_id}</option>;
                     })
                   ) : (
                     <i>No pods found</i>
@@ -91,7 +91,7 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
           className={styles['modal-footer']}
           isLoading={isLoading}
           error={error}
-          success={isSuccess ? `Successfully deleted a pod` : ''}
+          success={isSuccess ? `Successfully started a pod` : ''}
           reverse={true}
         >
           <Button
@@ -101,7 +101,7 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
             aria-label="Submit"
             type="submit"
           >
-            Delete pod
+            Start pod
           </Button>
         </SubmitWrapper>
       }
@@ -109,4 +109,4 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   );
 };
 
-export default DeletePodModal;
+export default StartPodModal;

--- a/src/tapis-app/Pods/_components/PodFunctionBar/StartPodModal/index.ts
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/StartPodModal/index.ts
@@ -1,0 +1,3 @@
+import StartPodModal from './StartPodModal';
+
+export default StartPodModal;

--- a/src/tapis-app/Pods/_components/PodFunctionBar/StopPodModal/StopPodModal.module.scss
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/StopPodModal/StopPodModal.module.scss
@@ -1,0 +1,16 @@
+.modal-settings {
+  max-height: 38rem;
+  overflow-y: scroll;
+}
+
+.item {
+  border: 1px dotted lightgray;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-bottom: 1em;
+}
+
+.array {
+  border: 1px solid gray;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-bottom: 0.5em;
+}

--- a/src/tapis-app/Pods/_components/PodFunctionBar/StopPodModal/StopPodModal.tsx
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/StopPodModal/StopPodModal.tsx
@@ -2,19 +2,19 @@ import { Button } from 'reactstrap';
 import { Pods } from '@tapis/tapis-typescript';
 import { GenericModal } from 'tapis-ui/_common';
 import { SubmitWrapper } from 'tapis-ui/_wrappers';
-import { ToolbarModalProps } from '../PodToolbar';
+import { ToolbarModalProps } from '../PodFunctionBar';
 import { Form, Formik } from 'formik';
 import { FormikSelect } from 'tapis-ui/_common/FieldWrapperFormik';
-import { useDeletePod, useList } from 'tapis-hooks/pods';
+import { useStopPod, useList } from 'tapis-hooks/pods';
 import { useEffect, useCallback } from 'react';
-import styles from './DeletePodModal.module.scss';
+import styles from './StopPodModal.module.scss';
 import * as Yup from 'yup';
 import { useQueryClient } from 'react-query';
 import { default as queryKeys } from 'tapis-hooks/pods/queryKeys';
 import { useTapisConfig } from 'tapis-hooks';
 import { useLocation } from 'react-router-dom';
 
-const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
+const StopPodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   const { claims } = useTapisConfig();
   const effectiveUserId = claims['sub'].substring(
     0,
@@ -29,7 +29,7 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
     queryClient.invalidateQueries(queryKeys.list);
   }, [queryClient]);
 
-  const { deletePod, isLoading, error, isSuccess, reset } = useDeletePod();
+  const { stopPod, isLoading, error, isSuccess, reset } = useStopPod();
 
   useEffect(() => {
     reset();
@@ -46,13 +46,13 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   };
 
   const onSubmit = ({ podId }: { podId: string }) => {
-    deletePod(podId, { onSuccess });
+    stopPod(podId, { onSuccess });
   };
 
   return (
     <GenericModal
       toggle={toggle}
-      title="Delete Pod"
+      title="Stop Pod"
       backdrop={true}
       body={
         <div className={styles['modal-settings']}>
@@ -71,11 +71,11 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
                   data-testid="podId"
                 >
                   <option disabled value={''}>
-                    Select a pod to delete
+                    Select a pod to stop
                   </option>
                   {pods.length ? (
                     pods.map((pod) => {
-                      return <option key={pod.pod_id}>{pod.pod_id}</option>;
+                      return <option>{pod.pod_id}</option>;
                     })
                   ) : (
                     <i>No pods found</i>
@@ -91,7 +91,7 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
           className={styles['modal-footer']}
           isLoading={isLoading}
           error={error}
-          success={isSuccess ? `Successfully deleted a pod` : ''}
+          success={isSuccess ? `Successfully stopped a pod` : ''}
           reverse={true}
         >
           <Button
@@ -101,7 +101,7 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
             aria-label="Submit"
             type="submit"
           >
-            Delete pod
+            Stop pod
           </Button>
         </SubmitWrapper>
       }
@@ -109,4 +109,4 @@ const DeletePodModal: React.FC<ToolbarModalProps> = ({ toggle }) => {
   );
 };
 
-export default DeletePodModal;
+export default StopPodModal;

--- a/src/tapis-app/Pods/_components/PodFunctionBar/StopPodModal/index.ts
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/StopPodModal/index.ts
@@ -1,0 +1,3 @@
+import StopPodModal from './StopPodModal';
+
+export default StopPodModal;

--- a/src/tapis-app/Pods/_components/PodFunctionBar/index.ts
+++ b/src/tapis-app/Pods/_components/PodFunctionBar/index.ts
@@ -1,0 +1,3 @@
+import PodFunctionBar from './PodFunctionBar';
+
+export default PodFunctionBar;

--- a/src/tapis-app/Pods/_components/TooltipModal/TooltipModal.module.scss
+++ b/src/tapis-app/Pods/_components/TooltipModal/TooltipModal.module.scss
@@ -1,0 +1,20 @@
+.modal-settings {
+  max-height: 38rem;
+  overflow-y: scroll;
+}
+
+.item {
+  border: 1px dotted lightgray;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-bottom: 1em;
+}
+
+.array {
+  border: 1px solid gray;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.prewrap {
+  white-space: pre-wrap;
+}

--- a/src/tapis-app/Pods/_components/TooltipModal/TooltipModal.tsx
+++ b/src/tapis-app/Pods/_components/TooltipModal/TooltipModal.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { GenericModal } from 'tapis-ui/_common';
+import { ToolbarModalProps } from '../PodFunctionBar/PodFunctionBar';
+import styles from './TooltipModal.module.scss';
+// import { SubmitWrapper } from 'tapis-ui/_wrappers';
+// import { Button } from 'reactstrap';
+// import { Pods } from '@tapis/tapis-typescript';
+// import { Form, Formik } from 'formik';
+// import { FormikSelect } from 'tapis-ui/_common/FieldWrapperFormik';
+// import { useEffect, useCallback } from 'react';
+// import * as Yup from 'yup';
+// import { useQueryClient } from 'react-query';
+// import { default as queryKeys } from 'tapis-hooks/pods/queryKeys';
+// import { useTapisConfig } from 'tapis-hooks';
+
+const TooltipModal: React.FC<
+  ToolbarModalProps & { tooltipText: string; tooltipTitle?: string }
+> = ({ toggle, tooltipText, tooltipTitle = 'default tooltip title' }) => {
+  return (
+    <GenericModal
+      toggle={toggle}
+      title={tooltipTitle}
+      backdrop={true}
+      size="sm"
+      body={
+        <div className={`${styles['modal-settings']} ${styles['pre-wrap']}`}>
+          {tooltipText}
+        </div>
+      }
+      // footer={
+      //     <Button color="primary" onClick={toggle}>
+      //       Do Something
+      //     </Button>
+      // }
+    />
+  );
+};
+
+export default TooltipModal;

--- a/src/tapis-app/Pods/_components/TooltipModal/index.ts
+++ b/src/tapis-app/Pods/_components/TooltipModal/index.ts
@@ -1,0 +1,3 @@
+import TooltipModal from './TooltipModal';
+
+export default TooltipModal;

--- a/src/tapis-app/Pods/_components/index.ts
+++ b/src/tapis-app/Pods/_components/index.ts
@@ -1,1 +1,4 @@
 export { default as PodsNav } from './PodsNav';
+export { default as PodToolbar } from './PodToolbar';
+export { default as PodFunctionBar } from './PodFunctionBar';
+export { default as TooltipModal } from './TooltipModal';

--- a/src/tapis-app/_Router/Router.tsx
+++ b/src/tapis-app/_Router/Router.tsx
@@ -8,6 +8,7 @@ import Login from '../Login';
 import Dashboard from '../Dashboard';
 import Jobs from '../Jobs';
 import Systems from '../Systems';
+import Pods from '../Pods';
 import Files from '../Files';
 import Workflows from '../Workflows';
 import UIPatterns from '../UIPatterns';
@@ -47,6 +48,9 @@ const Router: React.FC = () => {
       </ProtectedRoute>
       <ProtectedRoute path="/ml-hub">
         {/* TODO: create ML Hub */}
+      </ProtectedRoute>
+      <ProtectedRoute path="/pods">
+        <Pods />
       </ProtectedRoute>
       <Route path="/uipatterns">
         <SectionHeader>UI Patterns</SectionHeader>

--- a/src/tapis-hooks/pods/index.ts
+++ b/src/tapis-hooks/pods/index.ts
@@ -1,4 +1,8 @@
 export { default as useList } from './useList';
+export { default as useLogs } from './useLogs';
 export { default as useDetails } from './useDetails';
 export { default as useMakeNewPod } from './useMakeNewPod';
 export { default as useDeletePod } from './useDeletePod';
+export { default as useStartPod } from './useStartPod';
+export { default as useRestartPod } from './useRestartPod';
+export { default as useStopPod } from './useStopPod';

--- a/src/tapis-hooks/pods/queryKeys.ts
+++ b/src/tapis-hooks/pods/queryKeys.ts
@@ -3,6 +3,10 @@ const QueryKeys = {
   details: 'pods/details',
   makeNewPod: 'pods/makeNewPod',
   deletePod: 'pods/deletePod',
+  getLogs: 'pods/getPodLogs',
+  startPod: 'pods/startPod',
+  restartPod: 'pods/restartPod',
+  stopPod: 'pods/stopPod',
 };
 
 export default QueryKeys;

--- a/src/tapis-hooks/pods/useLogs.ts
+++ b/src/tapis-hooks/pods/useLogs.ts
@@ -1,0 +1,24 @@
+import { useQuery, QueryObserverOptions } from 'react-query';
+import { logs } from 'tapis-api/pods';
+import { Pods } from '@tapis/tapis-typescript';
+import { useTapisConfig } from 'tapis-hooks';
+import QueryKeys from './queryKeys';
+
+const useLogs = (
+  params: Pods.GetPodLogsRequest,
+  options: QueryObserverOptions<Pods.PodLogsResponse, Error> = {}
+) => {
+  const { accessToken, basePath } = useTapisConfig();
+  const result = useQuery<Pods.PodLogsResponse, Error>(
+    [QueryKeys.getLogs, params, accessToken],
+    // Default to no token. This will generate a 403 when calling the list function
+    // which is expected behavior for not having a token
+    () => logs(params, basePath, accessToken?.access_token ?? ''),
+    {
+      enabled: !!accessToken,
+    }
+  );
+  return result;
+};
+
+export default useLogs;

--- a/src/tapis-hooks/pods/useRestartPod.ts
+++ b/src/tapis-hooks/pods/useRestartPod.ts
@@ -1,0 +1,44 @@
+import { useMutation, MutateOptions } from 'react-query';
+import { Pods } from '@tapis/tapis-typescript';
+import { restartPod } from '../../tapis-api/pods';
+import { useTapisConfig } from '../context';
+import QueryKeys from './queryKeys';
+
+type RestartPodHookParams = {
+  podId: string;
+};
+
+const useRestartPod = () => {
+  const { basePath, accessToken } = useTapisConfig();
+  const jwt = accessToken?.access_token || '';
+
+  // The useMutation react-query hook is used to call operations that make server-side changes
+  // (Other hooks would be used for data retrieval)
+  //
+  // In this case, mkdir helper is called to perform the operation
+  const { mutate, isLoading, isError, isSuccess, data, error, reset } =
+    useMutation<Pods.PodResponse, Error, RestartPodHookParams>(
+      [QueryKeys.restartPod, basePath, jwt],
+      ({ podId }) => restartPod(podId, basePath, jwt)
+    );
+
+  // Return hook object with loading states and login function
+  return {
+    isLoading,
+    isError,
+    isSuccess,
+    data,
+    error,
+    reset,
+    restartPod: (
+      podId: string,
+      // react-query options to allow callbacks such as onSuccess
+      options?: MutateOptions<Pods.PodResponse, Error, RestartPodHookParams>
+    ) => {
+      // Call mutate to trigger a single post-like API operation
+      return mutate({ podId }, options);
+    },
+  };
+};
+
+export default useRestartPod;

--- a/src/tapis-hooks/pods/useStartPod.ts
+++ b/src/tapis-hooks/pods/useStartPod.ts
@@ -1,0 +1,44 @@
+import { useMutation, MutateOptions } from 'react-query';
+import { Pods } from '@tapis/tapis-typescript';
+import { startPod } from '../../tapis-api/pods';
+import { useTapisConfig } from '../context';
+import QueryKeys from './queryKeys';
+
+type StartPodHookParams = {
+  podId: string;
+};
+
+const useStartPod = () => {
+  const { basePath, accessToken } = useTapisConfig();
+  const jwt = accessToken?.access_token || '';
+
+  // The useMutation react-query hook is used to call operations that make server-side changes
+  // (Other hooks would be used for data retrieval)
+  //
+  // In this case, mkdir helper is called to perform the operation
+  const { mutate, isLoading, isError, isSuccess, data, error, reset } =
+    useMutation<Pods.PodResponse, Error, StartPodHookParams>(
+      [QueryKeys.startPod, basePath, jwt],
+      ({ podId }) => startPod(podId, basePath, jwt)
+    );
+
+  // Return hook object with loading states and login function
+  return {
+    isLoading,
+    isError,
+    isSuccess,
+    data,
+    error,
+    reset,
+    startPod: (
+      podId: string,
+      // react-query options to allow callbacks such as onSuccess
+      options?: MutateOptions<Pods.PodResponse, Error, StartPodHookParams>
+    ) => {
+      // Call mutate to trigger a single post-like API operation
+      return mutate({ podId }, options);
+    },
+  };
+};
+
+export default useStartPod;

--- a/src/tapis-hooks/pods/useStopPod.ts
+++ b/src/tapis-hooks/pods/useStopPod.ts
@@ -1,0 +1,44 @@
+import { useMutation, MutateOptions } from 'react-query';
+import { Pods } from '@tapis/tapis-typescript';
+import { stopPod } from '../../tapis-api/pods';
+import { useTapisConfig } from '../context';
+import QueryKeys from './queryKeys';
+
+type StopPodHookParams = {
+  podId: string;
+};
+
+const useStopPod = () => {
+  const { basePath, accessToken } = useTapisConfig();
+  const jwt = accessToken?.access_token || '';
+
+  // The useMutation react-query hook is used to call operations that make server-side changes
+  // (Other hooks would be used for data retrieval)
+  //
+  // In this case, mkdir helper is called to perform the operation
+  const { mutate, isLoading, isError, isSuccess, data, error, reset } =
+    useMutation<Pods.PodResponse, Error, StopPodHookParams>(
+      [QueryKeys.stopPod, basePath, jwt],
+      ({ podId }) => stopPod(podId, basePath, jwt)
+    );
+
+  // Return hook object with loading states and login function
+  return {
+    isLoading,
+    isError,
+    isSuccess,
+    data,
+    error,
+    reset,
+    stopPod: (
+      podId: string,
+      // react-query options to allow callbacks such as onSuccess
+      options?: MutateOptions<Pods.PodResponse, Error, StopPodHookParams>
+    ) => {
+      // Call mutate to trigger a single post-like API operation
+      return mutate({ podId }, options);
+    },
+  };
+};
+
+export default useStopPod;

--- a/src/tapis-ui/_common/JSONDisplay/JSONDisplay.module.scss
+++ b/src/tapis-ui/_common/JSONDisplay/JSONDisplay.module.scss
@@ -7,3 +7,27 @@
   justify-content: space-between;
   margin-bottom: 0.5em;
 }
+
+.copyButtonRight {
+  margin-left: auto;
+  height: 2rem;
+  align-items: center;
+  font-size: 0.7em !important;
+  border-radius: 0 !important;
+  background-color: #f4f4f4 !important;
+  color: #333333 !important;
+}
+
+.toolbar-btn {
+  height: 2rem;
+  align-items: center;
+  margin-left: 0.5em;
+  font-size: 0.7em !important;
+  border-radius: 0 !important;
+  background-color: #f4f4f4 !important;
+  color: #333333 !important;
+}
+
+.nav-background {
+  background-color: rgba(157, 133, 239, 0.25) !important;
+}

--- a/src/tapis-ui/_common/JSONDisplay/JSONDisplay.tsx
+++ b/src/tapis-ui/_common/JSONDisplay/JSONDisplay.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState, useCallback } from 'react';
-import { Input, FormGroup, Label } from 'reactstrap';
+import { Input, FormGroup, Label, Button } from 'reactstrap';
 import { CopyButton } from 'tapis-ui/_common';
+import { TooltipModal } from 'tapis-app/Pods/_components';
 import styles from './JSONDisplay.module.scss';
+import { Icon } from 'tapis-ui/_common';
 
 const simplifyObject = (obj: any) => {
   const result = JSON.parse(JSON.stringify(obj));
@@ -51,10 +53,54 @@ const convertSets = (obj: any): any => {
 type JSONDisplayProps = {
   json: any;
   className?: string;
+  checkbox?: boolean;
+  jsonstringify?: boolean;
+  tooltipText?: string;
+  tooltipTitle?: string;
 };
 
-const JSONDisplay: React.FC<JSONDisplayProps> = ({ json, className }) => {
-  const [simplified, setSimplified] = useState(false);
+type ToolbarButtonProps = {
+  text: string;
+  icon: string;
+  onClick: () => void;
+  disabled: boolean;
+};
+
+export type ToolbarModalProps = {
+  toggle: () => void;
+};
+
+export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
+  text,
+  icon,
+  onClick,
+  disabled = true,
+  ...rest
+}) => {
+  return (
+    <div>
+      <Button
+        disabled={disabled}
+        onClick={onClick}
+        className={`${styles['toolbar-btn']} ${styles['nav-background']}`}
+        {...rest}
+      >
+        {icon && <Icon name={icon}></Icon>}
+        <span> {text}</span>
+      </Button>
+    </div>
+  );
+};
+
+const JSONDisplay: React.FC<JSONDisplayProps> = ({
+  json,
+  className,
+  tooltipText,
+  tooltipTitle,
+  checkbox = true,
+  jsonstringify = true,
+}) => {
+  const [simplified, setSimplified] = useState(true);
   const onChange = useCallback(() => {
     setSimplified(!simplified);
   }, [setSimplified, simplified]);
@@ -67,23 +113,56 @@ const JSONDisplay: React.FC<JSONDisplayProps> = ({ json, className }) => {
       ),
     [json, simplified]
   );
+
+  // Sometimes we want this transform, sometimes we don't.
+  const output_json = jsonstringify ? jsonString : json;
+
   // Determine line length of JSON to set textarea rows. As that's prettier than a second scrollbar.
-  const lines = jsonString.split('\n');
-  const lineLengths = lines.length;
+  const lines = output_json.split('\n');
+  const minRows = 5;
+  // Use this to control how large the textarea is. There's probably a better way to do this.
+  const availableSpace = Math.floor(window.innerHeight / 37); // Assuming each row is 20px tall
+  const lineLengths = Math.max(minRows, Math.min(lines.length, availableSpace));
+
+  const [modal, setModal] = useState<string | undefined>(undefined);
+
+  const toggle = () => {
+    setModal(undefined);
+  };
+
   return (
     <div className={className}>
       <div className={styles.controls}>
-        <FormGroup check>
-          <Label check size="sm" className={`form-field__label`}>
-            <Input type="checkbox" onChange={onChange} />
-            Simplified
-          </Label>
-        </FormGroup>
-        <CopyButton value={jsonString} />
+        {checkbox && (
+          <FormGroup check>
+            <Label check size="sm" className={`form-field__label`}>
+              <Input type="checkbox" onChange={onChange} />
+              Include Empty Parameters
+            </Label>
+          </FormGroup>
+        )}
+        <CopyButton value={output_json} className={styles.copyButtonRight} />
+        {tooltipText && (
+          <ToolbarButton
+            text=""
+            icon="bulb"
+            disabled={false}
+            onClick={() => setModal('tooltip')}
+            aria-label="tooltip"
+          />
+        )}
+
+        {tooltipText && modal === 'tooltip' && (
+          <TooltipModal
+            toggle={toggle}
+            tooltipText={tooltipText}
+            tooltipTitle={tooltipTitle}
+          />
+        )}
       </div>
       <Input
         type="textarea"
-        value={jsonString}
+        value={output_json}
         className={styles.json}
         rows={lineLengths}
         disabled={true}
@@ -93,3 +172,112 @@ const JSONDisplay: React.FC<JSONDisplayProps> = ({ json, className }) => {
 };
 
 export default JSONDisplay;
+
+// const iconNames = [
+//   'jobs',
+//   'zipped',
+//   'compress',
+//   'extract',
+//   'add-file',
+//   'add-folder',
+//   'add-project',
+//   'add',
+//   'alert',
+//   'allocations',
+//   'applications',
+//   'approved-boxed-reverse',
+//   'approved-boxed',
+//   'approved-reverse',
+//   'approved',
+//   'bar-graph',
+//   'boxed',
+//   'browser',
+//   'bulb',
+//   'burger',
+//   'calendar',
+//   'close-boxed',
+//   'close',
+//   'code',
+//   'compass',
+//   'contract',
+//   'conversation',
+//   'copy',
+//   'coversation-wait',
+//   'dashboard',
+//   'data-files',
+//   'data-processing',
+//   'denied-reverse',
+//   'denied',
+//   'dna',
+//   'document',
+//   'download',
+//   'edit-document',
+//   'exit',
+//   'expand',
+//   'file',
+//   'folder',
+//   'gear',
+//   'globe',
+//   'history-reverse',
+//   'history',
+//   'image',
+//   'jupyter',
+//   'link',
+//   'lock',
+//   'monitor',
+//   'move',
+//   'multiple-coversation',
+//   'my-data',
+//   'new-browser',
+//   'no-alert',
+//   'pending',
+//   'pie-graph-open',
+//   'pie-graph-reverse',
+//   'pie-graph',
+//   'project',
+//   'proposal-approved',
+//   'proposal-denied',
+//   'proposal-pending',
+//   'publications',
+//   'push-left',
+//   'push-right',
+//   'refresh',
+//   'rename',
+//   'reverse-order',
+//   'rotate-ccw',
+//   'rotate-cw',
+//   'save',
+//   'script',
+//   'search-folder',
+//   'search',
+//   'share',
+//   'sillouette',
+//   'simulation-reverse',
+//   'simulation',
+//   'subtract-file',
+//   'toolbox',
+//   'trash',
+//   'trophy',
+//   'unlock',
+//   'upload',
+//   'user-reverse',
+//   'user',
+//   'visualization',
+//   'zoom-in',
+//   'zoom-out'
+// ];
+// {
+//   /*
+//                 {iconNames.map((iconName, index) => (
+//                   <div key={index}>
+//                     <ToolbarButton
+//                       text={iconName}
+//                       icon={iconName}
+//                       disabled={false}
+//                       onClick={() => setModal('tooltip')}
+//                       aria-label="tooltip"
+//                     />
+//                     <br />
+//                   </div>
+//                 ))} */
+// }

--- a/src/tapis-ui/_common/Tabs/Tabs.module.scss
+++ b/src/tapis-ui/_common/Tabs/Tabs.module.scss
@@ -1,23 +1,54 @@
 .tab {
-  border-top-left-radius: 3px;
-  border-top-right-radius: 3px;
-  border-top: 1px dotted var(--global-color-primary--dark);
-  border-left: 1px dotted var(--global-color-primary--dark);
-  border-bottom: 1px dotted var(--global-color-primary-dark);
-  background-color: var(--global-color-primary--normal);
-  a {
-    color: var(--global-color-primary--xx-dark);
-    height: 2.5em;
-    font-size: 0.8em;
-  }
-  :hover {
-    cursor: pointer;
-  }
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-top: 1px solid;
+  border-left: 1px solid;
+  border-right: 1px solid;
+
+  height: 2rem;
+  align-items: center;
+  margin-left: 0.5em;
   margin-right: 2px;
+  margin-bottom: 0px;
+  font-size: 0.7em !important;
+  border-radius: 0px !important;
+  background-color: #f4f4f4 !important;
+  color: #333333 !important;
+  border-color: #afafaf;
+  padding: 0;
+
+  a {
+    color: #333333;
+    height: 3em;
+    font-size: 1em;
+  }
+
+  /// controls effect on hover
+  :hover {
+    height: 2rem;
+    margin-bottom: 1px;
+
+    text-decoration: none;
+    // background-color: rgba(28, 0, 119, 0.25) !important;
+    color: #333333 !important;
+
+    border: 1px solid transparent !important;
+    // border-color: rgb(255, 0, 0) !important;
+    border-top-left-radius: 0px !important;
+    border-top-right-radius: 0px !important;
+    border-top: 1px solid #545b62 !important;
+    border-left: 1px solid #545b62 !important;
+    border-right: 1px solid #545b62 !important;
+    margin-left: -1px;
+    margin-right: -0.75px;
+    margin-top: -0.75px;
+    // margin-bottom: 5px;
+    // border-bottom: 1px solid #545b62 !important;
+  }
 }
 
 .active {
-  background-color: var(--global-color-primary--xx-light);
+  background-color: rgba(157, 133, 239, 0.25) !important;
 }
 
 .pane {

--- a/src/tapis-ui/components/pods/PodDetail/PodDetail.tsx
+++ b/src/tapis-ui/components/pods/PodDetail/PodDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDetails } from 'tapis-hooks/pods';
+import { useDetails, useLogs } from 'tapis-hooks/pods';
 import { Pods } from '@tapis/tapis-typescript';
 import { DescriptionList, Tabs, JSONDisplay } from 'tapis-ui/_common';
 import { QueryWrapper } from 'tapis-ui/_wrappers';
@@ -8,15 +8,47 @@ const PodDetail: React.FC<{ podId: string }> = ({ podId }) => {
   const { data, isLoading, error } = useDetails({
     podId,
   });
+  const {
+    data: data2,
+    isLoading: isLoading2,
+    error: error2,
+  } = useLogs({
+    podId,
+  });
   const pod: Pods.PodResponseModel | undefined = data?.result;
+  const podLogs: Pods.LogsModel | undefined = data2?.result;
   return (
-    <QueryWrapper isLoading={isLoading} error={error}>
+    <QueryWrapper isLoading={isLoading || isLoading2} error={error || error2}>
       <h3>{pod?.pod_id}</h3>
       {pod && (
         <Tabs
           tabs={{
-            JSON: <JSONDisplay json={pod} />,
+            Definition: (
+              <JSONDisplay
+                json={pod}
+                tooltipTitle="Pod Definition"
+                tooltipText="This is the JSON definition of this Pod. Visit our live-docs for an exact schema: https://tapis-project.github.io/live-docs/?service=Pods"
+              />
+            ),
             Details: <DescriptionList data={pod} />,
+            Logs: (
+              <JSONDisplay
+                json={podLogs?.logs}
+                checkbox={false}
+                jsonstringify={false}
+                tooltipTitle="Logs"
+                tooltipText="Logs contain the stdout/stderr of the most recent Pod run. Use it to debug your pod during startup, to grab metrics, inspect logs, and output data from your Pod."
+              />
+            ),
+            'Action Logs': (
+              <JSONDisplay
+                json={podLogs?.action_logs}
+                checkbox={false}
+                jsonstringify={true}
+                tooltipTitle="Action Logs"
+                tooltipText="Pods saves pod interactions in an Action Logs ledger. User and system interaction with your pod is logged here."
+              />
+            ),
           }}
         />
       )}


### PR DESCRIPTION
## Overview:

## Related Github Issues:

- [TUI-354](https://github.com/tapis-project/tapis-ui/issues/354)

## Summary of Changes:
- Added Start/Restart/Stop modals at Pod view
- Modals auto fetch PodId for nice customer experience
- Logs and Actions Logs have tabs in Pod view
- Preliminary hint button to describe some windows.
	- Needs to be generalized and made available, but for now I'm content as most is self-explanatory.
- New formatting for `Tabs` globally to match our style. Changes to copy and hint buttons as well.
- Added width parameter to `Log In` button so it doesn't overflow to two lines (which looks ugly).

## Testing Steps:

1. Run npm run test.

## UI Photos:
![Screenshot from 2024-04-25 09-41-26](https://github.com/tapis-project/tapis-ui/assets/25347867/3c4ecf7b-fdac-4d43-9517-240d1d0e3db8)

## Notes:
Double yay.