### PR TITLE
Task/TUI-400-mlhub-datasets-page

### DIFF
--- a/src/app/MlHub/Datasets/Datasets.module.scss
+++ b/src/app/MlHub/Datasets/Datasets.module.scss
@@ -1,0 +1,8 @@
+.datasets-table {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.datasets-name-column {
+  text-overflow: ellipsis;
+}

--- a/src/app/MlHub/Datasets/Datasets.tsx
+++ b/src/app/MlHub/Datasets/Datasets.tsx
@@ -31,7 +31,7 @@ const Datasets: React.FC = () => {
               <td className={`${styles['dataset-name-column']}`}>
                 <Icon name="search-folder" />
                 <span>
-                  <Link to={`${path}/${dataset[0]}`}> {dataset[0]} </Link>
+                  <Link to={`${path}/${dataset[0]}`}>{dataset[0]}</Link>
                 </span>
               </td>
               <td>{dataset[1].downloads}</td>

--- a/src/app/MlHub/Datasets/Datasets.tsx
+++ b/src/app/MlHub/Datasets/Datasets.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Link, useRouteMatch } from 'react-router-dom';
+import { Datasets as DatasetsModule } from '@tapis/tapis-typescript';
+import { Icon, QueryWrapper } from '@tapis/tapisui-common';
+import { MLHub as Hooks } from '@tapis/tapisui-hooks';
+import { Table } from 'reactstrap';
+import styles from './Datasets.module.scss';
+
+const Datasets: React.FC = () => {
+  const { data, isLoading, error } = Hooks.Datasets.useList();
+  const datasets: DatasetsModule.DatasetShortInfo = data?.result ?? {};
+  const { path } = useRouteMatch();
+  console.log(datasets);
+
+  return (
+    <QueryWrapper
+      isLoading={isLoading}
+      error={error}
+      className={styles['datasets-table']}
+    >
+      <Table responsive striped>
+        <thead>
+          <tr>
+            <th>Dataset ID</th>
+            <th>Downloads</th>
+            <th>Last Modified</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(datasets).map((dataset) => (
+            <tr>
+              <td className={`${styles['dataset-name-column']}`}>
+                <Icon name="search-folder" />
+                <span>
+                  <Link to={`${path}/${dataset[0]}`}> {dataset[0]} </Link>
+                </span>
+              </td>
+              <td>{dataset[1].downloads}</td>
+              <td>{dataset[1].last_modified}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </QueryWrapper>
+  );
+};
+
+export default Datasets;

--- a/src/app/MlHub/Datasets/_Layout/Layout.tsx
+++ b/src/app/MlHub/Datasets/_Layout/Layout.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Router } from '../_Router';
+
+const Layout: React.FC = () => {
+  return <Router />;
+};
+
+export default Layout;

--- a/src/app/MlHub/Datasets/_Layout/index.ts
+++ b/src/app/MlHub/Datasets/_Layout/index.ts
@@ -1,0 +1,1 @@
+export { default as Layout } from './Layout';

--- a/src/app/MlHub/Datasets/_Router/Router.tsx
+++ b/src/app/MlHub/Datasets/_Router/Router.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {
+  Route,
+  useRouteMatch,
+  Switch,
+  RouteComponentProps,
+} from 'react-router-dom';
+import Datasets from '../Datasets';
+
+const Router: React.FC = () => {
+  const { path } = useRouteMatch();
+  return (
+    <Switch>
+      <Route path={`${path}`} exact>
+        <Datasets />
+      </Route>
+    </Switch>
+  );
+};
+
+export default Router;

--- a/src/app/MlHub/Datasets/_Router/index.ts
+++ b/src/app/MlHub/Datasets/_Router/index.ts
@@ -1,0 +1,1 @@
+export { default as Router } from './Router';

--- a/src/app/MlHub/Models/InferenceServerInfo.tsx
+++ b/src/app/MlHub/Models/InferenceServerInfo.tsx
@@ -3,6 +3,7 @@ import { MLHub as Hooks } from '@tapis/tapisui-hooks';
 import { JSONDisplay } from '@tapis/tapisui-common';
 import styles from './ModelDetails.module.scss';
 import { QueryWrapper } from '@tapis/tapisui-common';
+import { Link, useRouteMatch } from 'react-router-dom';
 
 type InferenceServerInfoProps = {
   modelId: string;
@@ -17,6 +18,9 @@ const InferenceServerInfo: React.FC<InferenceServerInfoProps> = ({
     isError,
     isLoading,
   } = Hooks.Models.useInferenceServerDetails({ modelId });
+
+  const { path } = useRouteMatch();
+  
   if (isLoading) {
     return <p>Loading...</p>;
   }
@@ -58,7 +62,9 @@ const InferenceServerInfo: React.FC<InferenceServerInfoProps> = ({
                     inference_endpoint:
                   </div>
                   <div className={`${styles['detail-info']}`}>
-                    {serverInfo.result.inference_endpoint}
+                  <span>
+                  <Link to={`${path}/${serverInfo.result.inference_endpoint}`}> {serverInfo.result.inference_endpoint} </Link>
+                </span>
                   </div>
                 </div>
               )}
@@ -77,7 +83,7 @@ const InferenceServerInfo: React.FC<InferenceServerInfoProps> = ({
                       inference_server_possible:
                     </div>
                     <div className={`${styles['detail-info']}`}>
-                      {serverInfo.result?.inference_server_possible}
+                      {String(serverInfo.result?.inference_server_possible)}
                     </div>
                   </div>
                 </>

--- a/src/app/MlHub/Models/InferenceServerInfo.tsx
+++ b/src/app/MlHub/Models/InferenceServerInfo.tsx
@@ -20,7 +20,7 @@ const InferenceServerInfo: React.FC<InferenceServerInfoProps> = ({
   } = Hooks.Models.useInferenceServerDetails({ modelId });
 
   const { path } = useRouteMatch();
-  
+
   if (isLoading) {
     return <p>Loading...</p>;
   }
@@ -35,7 +35,6 @@ const InferenceServerInfo: React.FC<InferenceServerInfoProps> = ({
 
   if (serverInfo) {
     const { message, metadata, result, status, version } = serverInfo;
-    // console.log ("serverInfo" , serverInfo)
 
     if (
       parseInt(serverInfo.status!) === 200 ||
@@ -62,9 +61,14 @@ const InferenceServerInfo: React.FC<InferenceServerInfoProps> = ({
                     inference_endpoint:
                   </div>
                   <div className={`${styles['detail-info']}`}>
-                  <span>
-                  <Link to={`${path}/${serverInfo.result.inference_endpoint}`}> {serverInfo.result.inference_endpoint} </Link>
-                </span>
+                    <span>
+                      <Link
+                        to={`${path}/${serverInfo.result.inference_endpoint}`}
+                      >
+                        {' '}
+                        {serverInfo.result.inference_endpoint}{' '}
+                      </Link>
+                    </span>
                   </div>
                 </div>
               )}

--- a/src/app/MlHub/_Router/Router.tsx
+++ b/src/app/MlHub/_Router/Router.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { Route, useRouteMatch, Switch } from 'react-router-dom';
 import { Dashboard } from '../Dashboard';
 import { Layout as ModelsLayout } from '../Models/_Layout';
-<<<<<<< HEAD
 import { Layout as DatasetsLayout } from '../Datasets/_Layout';
-=======
-import { Layout as DatasetsLayout } from "../Datasets/_Layout"
->>>>>>> 96485ea75d8db4b48e864d20161e1a2e52551576
 
 const Router: React.FC = () => {
   const { path } = useRouteMatch();
@@ -19,14 +15,8 @@ const Router: React.FC = () => {
       <Route path={`${path}/models`}>
         <ModelsLayout />
       </Route>
-<<<<<<< HEAD
 
       <Route path={`${path}/datasets`}>
-=======
-      
-      <Route
-        path={`${path}/datasets`}>
->>>>>>> 96485ea75d8db4b48e864d20161e1a2e52551576
         <DatasetsLayout />
       </Route>
     </Switch>

--- a/src/app/MlHub/_Router/Router.tsx
+++ b/src/app/MlHub/_Router/Router.tsx
@@ -18,8 +18,7 @@ const Router: React.FC = () => {
       </Route>
 
       <Route
-        path={`${path}/datasets`}
-      >
+        path={`${path}/datasets`}>
         <DatasetsLayout />
       </Route> 
 

--- a/src/app/MlHub/_Router/Router.tsx
+++ b/src/app/MlHub/_Router/Router.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Route, useRouteMatch, Switch } from 'react-router-dom';
 import { Dashboard } from '../Dashboard';
 import { Layout as ModelsLayout } from '../Models/_Layout';
+import { Layout as DatasetsLayout } from "../Datasets/_Layout"
+
 
 const Router: React.FC = () => {
   const { path } = useRouteMatch();
@@ -14,6 +16,13 @@ const Router: React.FC = () => {
       <Route path={`${path}/models`}>
         <ModelsLayout />
       </Route>
+
+      <Route
+        path={`${path}/datasets`}
+      >
+        <DatasetsLayout />
+      </Route> 
+
     </Switch>
   );
 };

--- a/src/app/MlHub/_Router/Router.tsx
+++ b/src/app/MlHub/_Router/Router.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { Route, useRouteMatch, Switch } from 'react-router-dom';
 import { Dashboard } from '../Dashboard';
 import { Layout as ModelsLayout } from '../Models/_Layout';
-import { Layout as DatasetsLayout } from "../Datasets/_Layout"
-
+import { Layout as DatasetsLayout } from '../Datasets/_Layout';
 
 const Router: React.FC = () => {
   const { path } = useRouteMatch();
@@ -17,11 +16,9 @@ const Router: React.FC = () => {
         <ModelsLayout />
       </Route>
 
-      <Route
-        path={`${path}/datasets`}>
+      <Route path={`${path}/datasets`}>
         <DatasetsLayout />
-      </Route> 
-
+      </Route>
     </Switch>
   );
 };


### PR DESCRIPTION
## Overview:

## Related Github Issues:

- [TUI-1234](https://github.com/tapis-project/tapis-ui/issues/1234)

## Summary of Changes:
The main Datasets hub component has been added to 'src/app/MlHub’. It Displays top 100 datasets with info on dataset_id, downloads and last modified. The mlhub router has been changed to dispaly the Datasets page. The InferenceServerInfo component has been changed to display the  models' inference_endpoint as  a link and also display the boolean  inference_server_possible as string.

## Testing Steps:

1.

## UI Photos:

## Notes:
