### PR TITLE
Task/TUI 407 single dataset details

### DIFF
--- a/src/app/MlHub/Datasets/DatasetDetails.module.scss
+++ b/src/app/MlHub/Datasets/DatasetDetails.module.scss
@@ -1,0 +1,63 @@
+.dataset-details {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.buttons-container {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  gap: 20px;
+}
+
+.dataset-details-wrapper {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  position: relative;
+}
+
+.dataset-details {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex: 1;
+}
+
+.dataset-title {
+  padding-bottom: 8px;
+  margin-left: 10px;
+}
+
+.dataset-detail {
+  display: flex;
+  flex-direction: row;
+}
+
+.dataset-title {
+  font-weight: bold;
+  width: 10vw;
+}
+
+.detail-info {
+  margin-left: 8px;
+  text-align: left;
+}
+
+.dataset-title-container {
+  border-bottom: 1px solid black;
+  margin-bottom: 8px;
+}
+
+.download-links {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 5px;
+}
+
+.download-url-button {
+  height: 40px;
+}

--- a/src/app/MlHub/Datasets/DatasetDetails.tsx
+++ b/src/app/MlHub/Datasets/DatasetDetails.tsx
@@ -1,0 +1,238 @@
+import React, { useState } from 'react';
+import { Datasets } from '@tapis/tapis-typescript';
+import { MLHub as Hooks } from '@tapis/tapisui-hooks';
+import { QueryWrapper } from '@tapis/tapisui-common';
+import { Button } from 'reactstrap';
+import styles from './DatasetDetails.module.scss';
+import { Icon, JSONDisplay, GenericModal } from '@tapis/tapisui-common';
+
+type DatasetDetailsProps = {
+  datasetId: string;
+};
+
+const DatasetDetails: React.FC<DatasetDetailsProps> = ({ datasetId }) => {
+  const { data, isLoading, error } = Hooks.Datasets.useDetails({ datasetId });
+  const dataset: Datasets.DatasetFullInfo = data?.result ?? {};
+  return (
+    <QueryWrapper
+      isLoading={isLoading}
+      error={error}
+      className={styles['dataset-details']}
+    >
+      <div className={`${styles['dataset-title-container']}`}>
+        <div className={`${styles['dataset-title']}`}>
+          <b>{datasetId}</b>
+        </div>
+      </div>
+      <div className={`${styles['dataset-details-wrapper']}`}>
+        <div className={`${styles['dataset-details']}`}>
+          {dataset.author && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>author:</div>
+              <div className={`${styles['dataset-info']}`}>
+                {dataset.author}
+              </div>
+            </div>
+          )}
+
+          {dataset.downloads && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>downloads:</div>
+              <div className={`${styles['detail-info']}`}>
+                {dataset.downloads}
+              </div>
+            </div>
+          )}
+
+          {dataset.last_modified && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>created_at:</div>
+              <div className={`${styles['detail-info']}`}>
+                {dataset.created_at}
+              </div>
+            </div>
+          )}
+
+          {dataset.last_modified && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>last_modified:</div>
+              <div className={`${styles['detail-info']}`}>
+                {dataset.last_modified}
+              </div>
+            </div>
+          )}
+
+          {dataset.tags && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>last_modified:</div>
+              <div className={`${styles['detail-info']}`}>{dataset.tags}</div>
+            </div>
+          )}
+
+          {dataset.sha && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>sha:</div>
+              <div className={`${styles['detail-info']}`}>{dataset.sha}</div>
+            </div>
+          )}
+
+          {dataset.repository_content && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>
+                repository_content:
+              </div>
+
+              <div className={`${styles['detail-info']}`}>
+                {dataset.repository_content && (
+                  <JSONDisplay json={dataset.repository_content}></JSONDisplay>
+                )}
+              </div>
+            </div>
+          )}
+
+          {dataset.description && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>description:</div>
+              <div className={`${styles['detail-info']}`}>
+                {dataset.description}
+              </div>
+            </div>
+          )}
+
+          {dataset.paperswithcode_id && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>
+                paperswithcode_id:
+              </div>
+              <div className={`${styles['detail-info']}`}>
+                {dataset.paperswithcode_id}
+              </div>
+            </div>
+          )}
+
+          {dataset.citation && (
+            <div className={`${styles['dataset-detail']}`}>
+              <div className={`${styles['dataset-title']}`}>citation:</div>
+              <div className={`${styles['detail-info']}`}>
+                {dataset.citation}
+              </div>
+            </div>
+          )}
+        </div>
+        <Buttons datasetId={datasetId} />
+      </div>
+    </QueryWrapper>
+  );
+};
+
+const Buttons: React.FC<{ datasetId: string }> = ({ datasetId }) => {
+  const [currentDataset, setCurrentDataset] = useState<string | undefined>(
+    undefined
+  );
+
+  const { data, error, isLoading } = Hooks.Datasets.useDetails({ datasetId });
+
+  const datasetCardDetails: Datasets.DatasetFullInfo = data?.result ?? {};
+
+  const {
+    data: downloadLinkData,
+    error: downloadLinkError,
+    isLoading: downloadLinkIsLoading,
+  } = Hooks.Datasets.useDownloadLinks({ datasetId });
+
+  const downloadLinkInfo: Datasets.DatasetDownloadInfo =
+    downloadLinkData?.result ?? {};
+
+  const downloadOnClick = (url: string, filename: string) => {
+    fetch(url).then((response) => {
+      response.blob().then((blob) => {
+        const fileURL = window.URL.createObjectURL(blob);
+        let alink = document.createElement('a');
+        alink.href = fileURL;
+        alink.download = filename;
+        document.body.appendChild(alink);
+        alink.click();
+        document.body.removeChild(alink);
+
+        window.URL.revokeObjectURL(fileURL);
+      });
+    });
+  };
+
+  return (
+    <div className={`${styles['buttons-container']}`}>
+      <Button
+        onClick={() => {
+          setCurrentDataset('downloaddataset');
+        }}
+      >
+        {'Download Dataset '}
+        <span>
+          <Icon name="push-right" />
+        </span>
+      </Button>
+
+      <Button
+        onClick={() => {
+          setCurrentDataset('datasetcard');
+        }}
+      >
+        {'Dataset Card '}
+        <span>
+          <Icon name="push-right" />
+        </span>
+      </Button>
+
+      {currentDataset === 'datasetcard' && (
+        <GenericModal
+          toggle={() => {
+            setCurrentDataset(undefined);
+          }}
+          title="Dataset Card"
+          body={
+            <div>
+              {datasetId}
+              {datasetCardDetails.card_data && (
+                <JSONDisplay json={datasetCardDetails.card_data} />
+              )}
+            </div>
+          }
+        />
+      )}
+
+      {currentDataset === 'downloaddataset' && (
+        <GenericModal
+          toggle={() => {
+            setCurrentDataset(undefined);
+          }}
+          title="Download Dataset"
+          body={
+            <div className={`${styles['download-body']}`}>
+              {downloadLinkInfo?.download_links &&
+                Object.entries(downloadLinkInfo.download_links).map(
+                  ([filename, url]) => {
+                    return (
+                      <div className={`${styles['download-links']}`}>
+                        <div>{filename}:</div>
+                        <div></div>
+                        <div className={`${styles['download-url-button']}`}>
+                          <Button
+                            onClick={() => downloadOnClick(url, filename)}
+                          >
+                            {' '}
+                            Download{' '}
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  }
+                )}
+            </div>
+          }
+        />
+      )}
+    </div>
+  );
+};
+
+export default DatasetDetails;

--- a/src/app/MlHub/Datasets/_Router/Router.tsx
+++ b/src/app/MlHub/Datasets/_Router/Router.tsx
@@ -6,6 +6,7 @@ import {
   RouteComponentProps,
 } from 'react-router-dom';
 import Datasets from '../Datasets';
+import DatasetDetails from '../DatasetDetails';
 
 const Router: React.FC = () => {
   const { path } = useRouteMatch();
@@ -14,6 +15,17 @@ const Router: React.FC = () => {
       <Route path={`${path}`} exact>
         <Datasets />
       </Route>
+
+      <Route
+        path={`${path}/:datasetId+`}
+        render={({
+          match: {
+            params: { datasetId },
+          },
+        }: RouteComponentProps<{ datasetId: string }>) => {
+          return <DatasetDetails datasetId={datasetId} />;
+        }}
+      />
     </Switch>
   );
 };


### PR DESCRIPTION
## Overview:

## Related Github Issues:

- [TUI-1234](https://github.com/tapis-project/tapis-ui/issues/1234)

## Summary of Changes:
The main DatasetsDeatils component has been added to 'src/app/MlHub/Datasets’. It Displays author, download, created_at, last_modified, tags, sha, repository_content, description, paperswithcode_id, and citation.
The page display  two clickable buttons of Download Dataset, and Dataset Card. Download Dataset display the download_links to download the datasets. 
The Dataset Card button display the card_data. 
The Dataset.module.scss has been added to 'src/app/MlHub/Datasets’.
The router in Datasets has updated to display the result.

## Testing Steps:

1.

## UI Photos:
![image](https://github.com/user-attachments/assets/0f648d1e-8790-4ae5-8c6d-b10a87fd6919)
![image](https://github.com/user-attachments/assets/265dcca0-7148-40df-b3a9-4b7976aee383)
![image](https://github.com/user-attachments/assets/0a115c1b-9a0c-4461-b980-f32c088fe8a5)




## Notes:
