### PR TITLE
Task/t UI 441 render permissions error for systems not owned

### DIFF
--- a/packages/tapisui-api/src/utils/errorDecoder.test.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.test.ts
@@ -31,6 +31,6 @@ describe('Error Decoder', () => {
       () => new Promise((_, reject) => reject(jsonError))
     );
     
-    return expect(promise).rejects.toThrow('An unexpected error occurred');
+    return expect(promise).rejects.toThrow('JSON error');
   });
 });

--- a/packages/tapisui-api/src/utils/errorDecoder.test.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.test.ts
@@ -24,13 +24,13 @@ describe('Error Decoder', () => {
   it('Returns a json error', () => {
     // The json method returns a Promise
     const jsonError = { 
-      json: () => Promise.resolve({ message: 'JSON error' })
+      json: () => Promise.resolve({ message: 'An unexpected error occurred' })
     };
 
     const promise = errorDecoder<ResultType>(
       () => new Promise((_, reject) => reject(jsonError))
     );
     
-    return expect(promise).rejects.toThrow('JSON error');
+    return expect(promise).rejects.toThrow('An unexpected error occurred');
   });
 });

--- a/packages/tapisui-api/src/utils/errorDecoder.test.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.test.ts
@@ -24,7 +24,7 @@ describe('Error Decoder', () => {
   it('Returns a json error', () => {
     // The json method returns a Promise
     const jsonError = { 
-      json: () => Promise.resolve({ message: 'An unexpected error occurred' })
+      json: () => Promise.resolve({ message: 'JSON error' })
     };
 
     const promise = errorDecoder<ResultType>(

--- a/packages/tapisui-api/src/utils/errorDecoder.test.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.test.ts
@@ -22,7 +22,7 @@ describe('Error Decoder', () => {
   });
 
   it('Returns a json error', () => {
-    const jsonError = { json: () => 'An unexpected error occurred' };
+    const jsonError = { json: () => 'JSON error' };
     const promise = errorDecoder<ResultType>(
       () => new Promise((_, reject) => reject(jsonError))
     );

--- a/packages/tapisui-api/src/utils/errorDecoder.test.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.test.ts
@@ -22,10 +22,10 @@ describe('Error Decoder', () => {
   });
 
   it('Returns a json error', () => {
-    const jsonError = { json: () => 'JSON error' };
+    const jsonError = { json: () => 'An unexpected error occurred' };
     const promise = errorDecoder<ResultType>(
       () => new Promise((_, reject) => reject(jsonError))
     );
-    return expect(promise).rejects.toBe('JSON error');
+    return expect(promise).rejects.toBe('An unexpected error occurred');
   });
 });

--- a/packages/tapisui-api/src/utils/errorDecoder.test.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.test.ts
@@ -14,7 +14,7 @@ describe('Error Decoder', () => {
     return expect(promise).resolves.toBe(mockResult);
   });
 
-  it('Returns a non json error', () => {
+  it('Returns a non-json error', () => {
     const promise = errorDecoder<ResultType>(
       () => new Promise((_, reject) => reject('Mock error'))
     );
@@ -22,10 +22,15 @@ describe('Error Decoder', () => {
   });
 
   it('Returns a json error', () => {
-    const jsonError = { json: () => 'JSON error' };
+    // The json method returns a Promise
+    const jsonError = { 
+      json: () => Promise.resolve({ message: 'An unexpected error occurred' })
+    };
+
     const promise = errorDecoder<ResultType>(
       () => new Promise((_, reject) => reject(jsonError))
     );
-    return expect(promise).rejects.toBe('An unexpected error occurred');
+    
+    return expect(promise).rejects.toThrow('An unexpected error occurred');
   });
 });

--- a/packages/tapisui-api/src/utils/errorDecoder.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.ts
@@ -11,7 +11,7 @@ const errorDecoder = async <T>(func: () => Promise<T>): Promise<T> => {
     // Check if the error has a 'json' method to handle specific API errors
     if ((error as DecodableError).json) {
       const decoded = await (error as DecodableError).json();
-      const message = decoded.message || 'An unexpected error occurred';
+      const message = decoded.message || 'JSON error';
       throw new Error(message); // Throw the decoded error message
     } else {
       // Rethrow the error if it's not decodable

--- a/packages/tapisui-api/src/utils/errorDecoder.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.ts
@@ -11,7 +11,7 @@ const errorDecoder = async <T>(func: () => Promise<T>): Promise<T> => {
     // Check if the error has a 'json' method to handle specific API errors
     if ((error as DecodableError).json) {
       const decoded = await (error as DecodableError).json();
-      const message = decoded.message || 'JSON error';
+      const message = decoded.message || 'An unexpected error occurred';
       throw new Error(message); // Throw the decoded error message
     } else {
       // Rethrow the error if it's not decodable

--- a/packages/tapisui-api/src/utils/errorDecoder.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.ts
@@ -8,7 +8,11 @@ const errorDecoder = async <T>(func: () => Promise<T>) => {
     // rethrow it
     if ((error as any).json) {
       const decoded = await (error as any).json();
-      throw decoded;
+      let message = decoded.message;
+      if (message === undefined) {
+        throw new Error('An unexpected Error occured ');
+      }
+      throw new Error(decoded.message);
     } else {
       throw error;
     }

--- a/packages/tapisui-api/src/utils/errorDecoder.ts
+++ b/packages/tapisui-api/src/utils/errorDecoder.ts
@@ -1,19 +1,20 @@
-const errorDecoder = async <T>(func: () => Promise<T>) => {
+interface DecodableError {
+  json: () => Promise<{ message?: string }>;
+}
+
+const errorDecoder = async <T>(func: () => Promise<T>): Promise<T> => {
   try {
-    // Call the specified function name, and expect that specific return type
+    // Call the specified function and await its result
     const result: T = await func();
     return result;
   } catch (error) {
-    // If an exception occurred, try to decode the json response from it and
-    // rethrow it
-    if ((error as any).json) {
-      const decoded = await (error as any).json();
-      let message = decoded.message;
-      if (message === undefined) {
-        throw new Error('An unexpected Error occured ');
-      }
-      throw new Error(decoded.message);
+    // Check if the error has a 'json' method to handle specific API errors
+    if ((error as DecodableError).json) {
+      const decoded = await (error as DecodableError).json();
+      const message = decoded.message || 'An unexpected error occurred';
+      throw new Error(message); // Throw the decoded error message
     } else {
+      // Rethrow the error if it's not decodable
       throw error;
     }
   }

--- a/packages/tapisui-common/src/wrappers/QueryWrapper/QueryWrapper.tsx
+++ b/packages/tapisui-common/src/wrappers/QueryWrapper/QueryWrapper.tsx
@@ -21,7 +21,6 @@ const QueryWrapper: React.FC<QueryWrapperProps> = ({
       </div>
     );
   }
-
   if (error && error instanceof Error) {
     return (
       <div className={className}>

--- a/src/app/Systems/_Router/Router.tsx
+++ b/src/app/Systems/_Router/Router.tsx
@@ -10,29 +10,31 @@ import { SectionMessage } from '@tapis/tapisui-common';
 
 const Router: React.FC = () => {
   const { path } = useRouteMatch();
-
-  return (
-    <Switch>
-      <Route path={`${path}`} exact>
-        <div style={{ margin: '1rem', flex: 1, overflow: 'auto' }}>
-          <SectionMessage type="info">
-            Select a system from the list.
-          </SectionMessage>
-        </div>
-      </Route>
-
-      <Route
-        path={`${path}/:systemId`}
-        render={({
-          match: {
-            params: { systemId },
-          },
-        }: RouteComponentProps<{ systemId: string }>) => (
-          <SystemDetail systemId={systemId} />
-        )}
-      />
-    </Switch>
-  );
-};
+    return (
+      <Switch>
+        <Route path={`${path}`} exact>
+          <div style={{ margin: '1rem', flex: 1, overflow: 'auto' }}>
+            <SectionMessage type="info">
+              Select a system from the list.
+            </SectionMessage>
+          </div>
+        </Route>
+    
+        <Route
+          path={`${path}/:systemId`}
+          render={({
+            match: {
+              params: { systemId },
+            },
+          }: RouteComponentProps<{ systemId: string }>) => {
+            return (
+                <SystemDetail systemId={systemId} />
+            );
+          }}
+        />
+      </Switch>
+    );
+  }
+    
 
 export default Router;

--- a/src/app/Systems/_Router/Router.tsx
+++ b/src/app/Systems/_Router/Router.tsx
@@ -10,31 +10,28 @@ import { SectionMessage } from '@tapis/tapisui-common';
 
 const Router: React.FC = () => {
   const { path } = useRouteMatch();
-    return (
-      <Switch>
-        <Route path={`${path}`} exact>
-          <div style={{ margin: '1rem', flex: 1, overflow: 'auto' }}>
-            <SectionMessage type="info">
-              Select a system from the list.
-            </SectionMessage>
-          </div>
-        </Route>
-    
-        <Route
-          path={`${path}/:systemId`}
-          render={({
-            match: {
-              params: { systemId },
-            },
-          }: RouteComponentProps<{ systemId: string }>) => {
-            return (
-                <SystemDetail systemId={systemId} />
-            );
-          }}
-        />
-      </Switch>
-    );
-  }
-    
+  return (
+    <Switch>
+      <Route path={`${path}`} exact>
+        <div style={{ margin: '1rem', flex: 1, overflow: 'auto' }}>
+          <SectionMessage type="info">
+            Select a system from the list.
+          </SectionMessage>
+        </div>
+      </Route>
+
+      <Route
+        path={`${path}/:systemId`}
+        render={({
+          match: {
+            params: { systemId },
+          },
+        }: RouteComponentProps<{ systemId: string }>) => {
+          return <SystemDetail systemId={systemId} />;
+        }}
+      />
+    </Switch>
+  );
+};
 
 export default Router;

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.module.scss
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.module.scss
@@ -3,7 +3,6 @@
   height: 1340px;
   overflow: auto;
 
-
   // Customize the scrollbar itself
   &::-webkit-scrollbar {
     width: 11px;

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.module.scss
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.module.scss
@@ -1,0 +1,25 @@
+// Customize the scrollbar for a specific container
+.scroll-container {
+    width: 340px;
+    height: 1340px;
+    overflow: auto; 
+  
+    // Customize the scrollbar itself
+    &::-webkit-scrollbar {
+      width: 11px; 
+      height: 200px; 
+    }
+  
+    // Customize the scrollbar track (the area the scrollbar slides in)
+    &::-webkit-scrollbar-track {
+      background-color: #f1f1f1;
+      border-radius: 10px;
+    }
+  
+    // Customize the scrollbar thumb
+    &::-webkit-scrollbar-thumb {
+      background-color: #888;
+      border-radius: 10px;
+    }
+
+  }

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.module.scss
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.module.scss
@@ -1,6 +1,6 @@
 // Customize the scrollbar for a specific container
 .scroll-container {
-    width: 340px;
+    width: 300px;
     height: 1340px;
     overflow: auto; 
   

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.module.scss
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.module.scss
@@ -1,25 +1,24 @@
 // Customize the scrollbar for a specific container
 .scroll-container {
-    width: 300px;
-    height: 1340px;
-    overflow: auto; 
-  
-    // Customize the scrollbar itself
-    &::-webkit-scrollbar {
-      width: 11px; 
-      height: 200px; 
-    }
-  
-    // Customize the scrollbar track (the area the scrollbar slides in)
-    &::-webkit-scrollbar-track {
-      background-color: #f1f1f1;
-      border-radius: 10px;
-    }
-  
-    // Customize the scrollbar thumb
-    &::-webkit-scrollbar-thumb {
-      background-color: #888;
-      border-radius: 10px;
-    }
+  height: 1340px;
+  overflow: auto;
 
+
+  // Customize the scrollbar itself
+  &::-webkit-scrollbar {
+    width: 11px;
+    height: 200px;
   }
+
+  // Customize the scrollbar track (the area the scrollbar slides in)
+  &::-webkit-scrollbar-track {
+    background-color: #f1f1f1;
+    border-radius: 10px;
+  }
+
+  // Customize the scrollbar thumb
+  &::-webkit-scrollbar-thumb {
+    background-color: #888;
+    border-radius: 10px;
+  }
+}

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -12,11 +12,7 @@ import {
   Lock,
   LockOpen,
 } from '@mui/icons-material';
-import {
-  Alert,
-  AlertTitle
-}
-from '@mui/material'
+import { Alert, AlertTitle } from '@mui/material';
 import UndeleteSystemModal from '../SystemToolbar/UndeleteSystemModal';
 import styles from './SystemsNav.module.scss';
 
@@ -25,10 +21,9 @@ const SystemsNav: React.FC = () => {
     undefined
   );
 
-  
   const { url } = useRouteMatch();
   const history = useHistory();
-  
+
   // Fetch systems listing
   const { data, isLoading, error } = Hooks.useList({
     listType: Systems.ListTypeEnum.All,
@@ -36,7 +31,7 @@ const SystemsNav: React.FC = () => {
     computeTotal: true,
     limit: 1000,
   });
-  
+
   // Fetch deleted systems listing
   const {
     data: deletedData,
@@ -46,11 +41,15 @@ const SystemsNav: React.FC = () => {
   const deletedSystems: Array<Systems.TapisSystem> = deletedData?.result ?? [];
   const systems: Array<Systems.TapisSystem> = data?.result ?? [];
 
-  const {reset} = Hooks.useDisableSystem({systemId:"systems"})
-  
-  const {data:permsData, isError, error:permsError} = Hooks.useGetUserPerms({
-    systemId:'systemId'
-  })
+  const { reset } = Hooks.useDisableSystem({ systemId: 'systems' });
+
+  const {
+    data: permsData,
+    isError,
+    error: permsError,
+  } = Hooks.useGetUserPerms({
+    systemId: 'systemId',
+  });
   return (
     <QueryWrapper isLoading={isLoading} error={[error]}>
       <div
@@ -133,7 +132,7 @@ const SystemsNav: React.FC = () => {
                   <LockOpen color="success" />
                 ) : (
                   <Lock color="error" />
-                )
+                ),
             },
           ]}
         >

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -12,11 +12,7 @@ import {
   Lock,
   LockOpen,
 } from '@mui/icons-material';
-import {
-  Alert,
-  AlertTitle
-}
-from '@mui/material'
+import { Alert, AlertTitle } from '@mui/material';
 import UndeleteSystemModal from '../SystemToolbar/UndeleteSystemModal';
 import styles from './SystemsNav.module.scss';
 
@@ -25,10 +21,9 @@ const SystemsNav: React.FC = () => {
     undefined
   );
 
-  
   const { url } = useRouteMatch();
   const history = useHistory();
-  
+
   // Fetch systems listing
   const { data, isLoading, error } = Hooks.useList({
     listType: Systems.ListTypeEnum.All,
@@ -36,7 +31,7 @@ const SystemsNav: React.FC = () => {
     computeTotal: true,
     limit: 1000,
   });
-  
+
   // Fetch deleted systems listing
   const {
     data: deletedData,
@@ -128,7 +123,7 @@ const SystemsNav: React.FC = () => {
                   <LockOpen color="success" />
                 ) : (
                   <Lock color="error" />
-                )
+                ),
             },
           ]}
         >

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -12,6 +12,11 @@ import {
   Lock,
   LockOpen,
 } from '@mui/icons-material';
+import {
+  Alert,
+  AlertTitle
+}
+from '@mui/material'
 import UndeleteSystemModal from '../SystemToolbar/UndeleteSystemModal';
 import styles from './SystemsNav.module.scss';
 
@@ -20,18 +25,18 @@ const SystemsNav: React.FC = () => {
     undefined
   );
 
+  
   const { url } = useRouteMatch();
   const history = useHistory();
-
+  
   // Fetch systems listing
   const { data, isLoading, error } = Hooks.useList({
     listType: Systems.ListTypeEnum.All,
     select: 'allAttributes',
     computeTotal: true,
-    limit: 1000
+    limit: 1000,
   });
   
-
   // Fetch deleted systems listing
   const {
     data: deletedData,
@@ -41,6 +46,11 @@ const SystemsNav: React.FC = () => {
   const deletedSystems: Array<Systems.TapisSystem> = deletedData?.result ?? [];
   const systems: Array<Systems.TapisSystem> = data?.result ?? [];
 
+  const {reset} = Hooks.useDisableSystem({systemId:"systems"})
+  
+  const {data:permsData, isError, error:permsError} = Hooks.useGetUserPerms({
+    systemId:'systemId'
+  })
   return (
     <QueryWrapper isLoading={isLoading} error={[error]}>
       <div
@@ -48,7 +58,7 @@ const SystemsNav: React.FC = () => {
           borderBottom: '1px solid #CCCCCC',
           borderRight: '1px solid #CCCCCC',
         }}
-        className={styles["scroll-container"]}
+        className={styles['scroll-container']}
       >
         <FilterableObjectsList
           objects={systems}
@@ -123,7 +133,7 @@ const SystemsNav: React.FC = () => {
                   <LockOpen color="success" />
                 ) : (
                   <Lock color="error" />
-                ),
+                )
             },
           ]}
         >

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -46,11 +46,7 @@ const SystemsNav: React.FC = () => {
   const deletedSystems: Array<Systems.TapisSystem> = deletedData?.result ?? [];
   const systems: Array<Systems.TapisSystem> = data?.result ?? [];
 
-  const {reset} = Hooks.useDisableSystem({systemId:"systems"})
-  
-  const {data:permsData, isError, error:permsError} = Hooks.useGetUserPerms({
-    systemId:'systemId'
-  })
+
   return (
     <QueryWrapper isLoading={isLoading} error={[error]}>
       <div

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -31,7 +31,6 @@ const SystemsNav: React.FC = () => {
     limit: 1000,
   });
 
-
   // Fetch deleted systems listing
   const {
     data: deletedData,
@@ -40,7 +39,6 @@ const SystemsNav: React.FC = () => {
   } = Hooks.useDeletedList();
   const deletedSystems: Array<Systems.TapisSystem> = deletedData?.result ?? [];
   const systems: Array<Systems.TapisSystem> = data?.result ?? [];
-
 
   return (
     <QueryWrapper isLoading={isLoading} error={[error]}>

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -13,6 +13,7 @@ import {
   LockOpen,
 } from '@mui/icons-material';
 import UndeleteSystemModal from '../SystemToolbar/UndeleteSystemModal';
+import styles from './SystemsNav.module.scss';
 
 const SystemsNav: React.FC = () => {
   const [undeleteSystem, setUndeleteSystem] = useState<string | undefined>(
@@ -27,7 +28,9 @@ const SystemsNav: React.FC = () => {
     listType: Systems.ListTypeEnum.All,
     select: 'allAttributes',
     computeTotal: true,
+    limit: 1000
   });
+  
 
   // Fetch deleted systems listing
   const {
@@ -45,6 +48,7 @@ const SystemsNav: React.FC = () => {
           borderBottom: '1px solid #CCCCCC',
           borderRight: '1px solid #CCCCCC',
         }}
+        className={styles["scroll-container"]}
       >
         <FilterableObjectsList
           objects={systems}

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -28,8 +28,9 @@ const SystemsNav: React.FC = () => {
     listType: Systems.ListTypeEnum.All,
     select: 'allAttributes',
     computeTotal: true,
-    limit: 1000,
+    limit: 1000
   });
+  
 
   // Fetch deleted systems listing
   const {
@@ -47,7 +48,7 @@ const SystemsNav: React.FC = () => {
           borderBottom: '1px solid #CCCCCC',
           borderRight: '1px solid #CCCCCC',
         }}
-        className={styles['scroll-container']}
+        className={styles["scroll-container"]}
       >
         <FilterableObjectsList
           objects={systems}

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -16,7 +16,6 @@ import { Alert, AlertTitle } from '@mui/material';
 import UndeleteSystemModal from '../SystemToolbar/UndeleteSystemModal';
 import styles from './SystemsNav.module.scss';
 
-
 const SystemsNav: React.FC = () => {
   const [undeleteSystem, setUndeleteSystem] = useState<string | undefined>(
     undefined
@@ -33,7 +32,6 @@ const SystemsNav: React.FC = () => {
     limit: 1000,
   });
 
-  const { mutate } = useMutation([data, isLoading, error]);
 
   // Fetch deleted systems listing
   const {
@@ -44,15 +42,7 @@ const SystemsNav: React.FC = () => {
   const deletedSystems: Array<Systems.TapisSystem> = deletedData?.result ?? [];
   const systems: Array<Systems.TapisSystem> = data?.result ?? [];
 
-  const { reset } = Hooks.useDisableSystem({ systemId: 'systems' });
 
-  const {
-    data: permsData,
-    isError,
-    error: permsError,
-  } = Hooks.useGetUserPerms({
-    systemId: 'systemId',
-  });
   return (
     <QueryWrapper isLoading={isLoading} error={[error]}>
       <div

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -12,7 +12,6 @@ import {
   Lock,
   LockOpen,
 } from '@mui/icons-material';
-import { Alert, AlertTitle } from '@mui/material';
 import UndeleteSystemModal from '../SystemToolbar/UndeleteSystemModal';
 import styles from './SystemsNav.module.scss';
 

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -12,6 +12,11 @@ import {
   Lock,
   LockOpen,
 } from '@mui/icons-material';
+import {
+  Alert,
+  AlertTitle
+}
+from '@mui/material'
 import UndeleteSystemModal from '../SystemToolbar/UndeleteSystemModal';
 import styles from './SystemsNav.module.scss';
 
@@ -20,18 +25,18 @@ const SystemsNav: React.FC = () => {
     undefined
   );
 
+  
   const { url } = useRouteMatch();
   const history = useHistory();
-
+  
   // Fetch systems listing
   const { data, isLoading, error } = Hooks.useList({
     listType: Systems.ListTypeEnum.All,
     select: 'allAttributes',
     computeTotal: true,
-    limit: 1000
+    limit: 1000,
   });
   
-
   // Fetch deleted systems listing
   const {
     data: deletedData,
@@ -41,6 +46,11 @@ const SystemsNav: React.FC = () => {
   const deletedSystems: Array<Systems.TapisSystem> = deletedData?.result ?? [];
   const systems: Array<Systems.TapisSystem> = data?.result ?? [];
 
+  const {reset} = Hooks.useDisableSystem({systemId:"systems"})
+  
+  const {data:permsData, isError, error:permsError} = Hooks.useGetUserPerms({
+    systemId:'systemId'
+  })
   return (
     <QueryWrapper isLoading={isLoading} error={[error]}>
       <div
@@ -48,7 +58,7 @@ const SystemsNav: React.FC = () => {
           borderBottom: '1px solid #CCCCCC',
           borderRight: '1px solid #CCCCCC',
         }}
-        className={styles["scroll-container"]}
+        className={styles['scroll-container']}
       >
         <FilterableObjectsList
           objects={systems}
@@ -123,10 +133,7 @@ const SystemsNav: React.FC = () => {
                   <LockOpen color="success" />
                 ) : (
                   <Lock color="error" />
-                ),
-              onClickItem: (object) => {
-                // TODO Trigger re-enable modal
-              },
+                )
             },
           ]}
         >

--- a/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
+++ b/src/app/Systems/_components/SystemsNav/SystemsNav.tsx
@@ -46,7 +46,6 @@ const SystemsNav: React.FC = () => {
   const deletedSystems: Array<Systems.TapisSystem> = deletedData?.result ?? [];
   const systems: Array<Systems.TapisSystem> = data?.result ?? [];
 
-
   return (
     <QueryWrapper isLoading={isLoading} error={[error]}>
       <div


### PR DESCRIPTION

<img width="1571" alt="Screenshot 2025-03-06 at 8 25 13 AM" src="https://github.com/user-attachments/assets/e7c4406f-f831-455f-b298-d267dc25e8fa" />
<img width="1578" alt="Screenshot 2025-03-06 at 8 25 39 AM" src="https://github.com/user-attachments/assets/c6319f94-8610-4bc8-a79d-8344d2e7b08c" />
<img width="1573" alt="Screenshot 2025-03-06 at 8 25 59 AM" src="https://github.com/user-attachments/assets/4b403d76-caaf-4e79-a5fe-2d0c9f2c0f76" />
<img width="754" alt="Screenshot 2025-03-06 at 8 27 28 AM" src="https://github.com/user-attachments/assets/6057dae6-22e9-438a-8ecc-7d69afd3e712" />
## Overview:

## Related Github Issues:

- [TUI-1234](https://github.com/tapis-project/tapis-ui/issues/1234)

## Summary of Changes:
Add scroll functionality to systems toolbar, remove system limit of 100, lock systems toolbar in place so user can scroll systems while keeping current system definition, fix error decoder. 

## Testing Steps:

1.

## UI Photos:

## Notes:
