### PR TITLE
add harvest extension

### DIFF
--- a/packages/icicle-tapisui-extension/src/index.ts
+++ b/packages/icicle-tapisui-extension/src/index.ts
@@ -14,6 +14,7 @@ import {
   CKNDashboard,
   DigitalAgOpenPASS,
   ComponentCatalog,
+  Harvest,
 } from './pages';
 
 const extension = createExtension({
@@ -44,6 +45,7 @@ const extension = createExtension({
     'jobs',
     'files',
     'apps',
+    'harvest',
     //'data-labeler',
     //'smart-scheduler',
   ],
@@ -128,6 +130,12 @@ extension.registerService({
   sidebarDisplayName: 'OpenPASS',
   iconName: 'globe',
   component: DigitalAgOpenPASS,
+});
+extension.registerService({
+  id: 'harvest',
+  sidebarDisplayName: 'Harvest',
+  iconName: 'globe',
+  component: Harvest,
 });
 
 extension.registerService({

--- a/packages/icicle-tapisui-extension/src/pages/Harvest/Harvest.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/Harvest/Harvest.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { SectionHeader } from '@tapis/tapisui-common';
+import { Component } from '@tapis/tapisui-extensions-core';
+export const Harvest: Component = ({ accessToken }) => {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {accessToken ? (
+        <iframe
+          style={{ flexGrow: 1, border: 'none' }}
+          src={`http://harvest-back.pods.icicleai.tapis.io/tapisui-entry?jwt=${accessToken}`}
+        />
+      ) : (
+        <>Invalid JWT. Log out of TapisUI then log back in</>
+      )}
+    </div>
+  );
+};
+export default Harvest;

--- a/packages/icicle-tapisui-extension/src/pages/Harvest/Harvest.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/Harvest/Harvest.tsx
@@ -15,7 +15,7 @@ export const Harvest: Component = ({ accessToken }) => {
       {accessToken ? (
         <iframe
           style={{ flexGrow: 1, border: 'none' }}
-          src={`http://harvest-back.pods.icicleai.tapis.io/tapisui-entry?jwt=${accessToken}`}
+          src={`https://harvest.pods.icicleai.tapis.io/`}
         />
       ) : (
         <>Invalid JWT. Log out of TapisUI then log back in</>

--- a/packages/icicle-tapisui-extension/src/pages/Harvest/index.ts
+++ b/packages/icicle-tapisui-extension/src/pages/Harvest/index.ts
@@ -1,0 +1,1 @@
+export { default as Harvest } from './Harvest';

--- a/packages/icicle-tapisui-extension/src/pages/index.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/index.tsx
@@ -9,3 +9,4 @@ export { TrainingCatalog } from './TrainingCatalog';
 export { CKNDashboard } from './CKNDashboard';
 export { CatalogAnalytics } from './CatalogAnalytics';
 export { ComponentCatalog } from './ComponentCatalog';
+export { Harvest } from './Harvest';


### PR DESCRIPTION
## Overview:
Adds ICICLE extension for Harvest
## Related Github Issues:

N/A

## Summary of Changes:
Create new extension that connects to Harvest created by the ICICLE Digital Agriculture team

