### PR TITLE
Task/t UI 484 Add Copy Access Token Button to MenuItems and ViewJWT Modal

### DIFF
--- a/src/app/_components/Sidebar/Sidebar.tsx
+++ b/src/app/_components/Sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   SettingsRounded,
   Key,
   Visibility,
+  ContentCopy
 } from '@mui/icons-material';
 import { LoadingButton as Button } from '@mui/lab';
 import {
@@ -145,6 +146,12 @@ const Sidebar: React.FC = () => {
   };
   const handleModal = () => {
     setModal('delete');
+  };
+
+  const handleCopyAccessToken = () => {
+    if (accessToken?.access_token) {
+      navigator.clipboard.writeText(accessToken.access_token);
+    }
   };
 
   const useCountdown = (targetTime: number) => {
@@ -383,6 +390,15 @@ const Sidebar: React.FC = () => {
           <ListItemText>View JWT</ListItemText>
         </MenuItem>
         <MenuItem
+          disabled={!(claims && claims["sub"]) || !accessToken?.access_token}
+          onClick={handleCopyAccessToken}
+        >
+          <ListItemIcon>
+            <ContentCopy fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Copy Access Token</ListItemText>
+        </MenuItem>
+        <MenuItem
           onClick={() => {
             history.push('/workflows/secrets');
           }}
@@ -434,7 +450,27 @@ const Sidebar: React.FC = () => {
         }}
       >
         <DialogContent>
-          <Typography variant="h6">Access Token Object</Typography>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: '8px',
+            }}
+          >
+            <Typography variant="h6">Access Token Object</Typography>
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<ContentCopy />}
+                onClick={handleCopyAccessToken}
+                disabled={!domainsMatched || !accessToken?.access_token}
+              >
+                Copy Access Token
+              </Button>
+            </div>
+          </div>
           <CodeMirror
             value={
               domainsMatched


### PR DESCRIPTION
## Overview: 
In this PR, I added two Copy Access Token buttons, one in the user menu items and one in the ViewJWT modal.

## Related Github Issues:  
[TUI-484](https://github.com/tapis-project/tapis-ui/issues/484)

## Testing Steps: 
By clicking these two buttons, we see that the access token can be successfully copied


## UI Photos:
<img width="507" height="246" alt="1" src="https://github.com/user-attachments/assets/7540df69-4001-4fe2-8e02-cf5886e8a406" />
<img width="962" height="571" alt="2" src="https://github.com/user-attachments/assets/6f47e88d-1046-4897-aa19-829f05ef2d65" />
