### PR TITLE
Task/t UI 468 add share button in file browser

### DIFF
--- a/src/app/Files/_components/Toolbar/ShareModal/ShareModal.tsx
+++ b/src/app/Files/_components/Toolbar/ShareModal/ShareModal.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Alert, AlertTitle, TextField, Stack } from "@mui/material";
+import { Button } from "reactstrap";
+import {
+  GenericModal,
+  TextCopyField,
+  SubmitWrapper,
+} from "@tapis/tapisui-common";
+import { ToolbarModalProps } from "../Toolbar";
+import { Files as Hooks } from "@tapis/tapisui-hooks";
+import { useFilesSelect } from "../../FilesContext";
+
+const DEFAULT_ALLOWED_USES = 1;
+const DEFAULT_VALID_SECONDS = 3600; // 1 hour
+
+const ShareModal: React.FC<ToolbarModalProps> = ({
+  toggle,
+  systemId = "",
+  path = "/",
+}) => {
+  const { selectedFiles, unselect } = useFilesSelect();
+  const { create, isLoading, isError, error, isSuccess, data, reset } =
+    Hooks.PostIts.useCreate();
+
+  const [allowedUses, setAllowedUses] = useState<number>(DEFAULT_ALLOWED_USES);
+  const [validSeconds, setValidSeconds] = useState<number>(
+    DEFAULT_VALID_SECONDS
+  );
+  const [redeemUrl, setRedeemUrl] = useState<string>("");
+
+  const selected = selectedFiles[0];
+  const isDir = selected?.type === "dir";
+  const isMultipleSelection = selectedFiles.length > 1;
+
+  const description = useMemo(() => {
+    if (!selected) return "";
+    const kind = isDir ? "folder" : "file";
+    return `You are creating a shareable link for the ${kind} "${selected.name}" at ${selected.path}.`;
+  }, [selected, isDir]);
+
+  useEffect(() => {
+    if (data?.result?.redeemUrl) {
+      setRedeemUrl(data.result.redeemUrl);
+    }
+  }, [data]);
+
+  const onGenerate = useCallback(() => {
+    if (!selected) return;
+    setRedeemUrl("");
+    create(
+      {
+        systemId,
+        path: selected.path!,
+        createPostItRequest: {
+          allowedUses,
+          validSeconds,
+        },
+      },
+      {
+        onSuccess: (resp) => {
+          setRedeemUrl(resp.result?.redeemUrl || "");
+        },
+      }
+    );
+  }, [create, systemId, selected, allowedUses, validSeconds]);
+
+  const onClose = useCallback(() => {
+    reset();
+    setRedeemUrl("");
+    unselect(selectedFiles);
+    toggle();
+  }, [reset, toggle, unselect, selectedFiles]);
+
+  return (
+    <GenericModal
+      size="lg"
+      toggle={onClose}
+      title={"Share via PostIt"}
+      body={
+        <div>
+          {isError && error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              <AlertTitle>Error creating link</AlertTitle>
+              {error.message}
+            </Alert>
+          )}
+          {isMultipleSelection && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              <AlertTitle>Multiple files selected</AlertTitle>
+              You have selected {selectedFiles.length} items. Only the first
+              item "{selected?.name}" will be shared. To share multiple files,
+              select them one at a time or create a folder containing all files.
+            </Alert>
+          )}
+          <p>{description}</p>
+          <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+            <TextField
+              label="Allowed Uses"
+              type="number"
+              size="small"
+              value={allowedUses}
+              onChange={(e) =>
+                setAllowedUses(Math.max(1, Number(e.target.value)))
+              }
+              inputProps={{ min: 1 }}
+            />
+            <TextField
+              label="Valid Seconds"
+              type="number"
+              size="small"
+              value={validSeconds}
+              onChange={(e) =>
+                setValidSeconds(Math.max(1, Number(e.target.value)))
+              }
+              inputProps={{ min: 1 }}
+            />
+          </Stack>
+          <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+            <SubmitWrapper
+              isLoading={isLoading}
+              error={null}
+              success={redeemUrl ? "Link created" : undefined}
+            >
+              <Button
+                color="primary"
+                onClick={onGenerate}
+                disabled={!selected || isMultipleSelection}
+              >
+                Generate Link
+              </Button>
+            </SubmitWrapper>
+            <div style={{ flex: 1 }}>
+              <TextCopyField
+                value={redeemUrl}
+                placeholder="Shareable link will appear here"
+              />
+            </div>
+          </div>
+          {isSuccess && redeemUrl && (
+            <Alert severity="success" sx={{ mt: 2 }}>
+              Link created. You can share this URL with users without
+              authentication.
+            </Alert>
+          )}
+        </div>
+      }
+    />
+  );
+};
+
+export default ShareModal;

--- a/src/app/Files/_components/Toolbar/ShareModal/ShareModal.tsx
+++ b/src/app/Files/_components/Toolbar/ShareModal/ShareModal.tsx
@@ -1,18 +1,18 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Alert, AlertTitle, TextField, Stack } from "@mui/material";
-import { Button } from "reactstrap";
-import { GenericModal, SubmitWrapper } from "@tapis/tapisui-common";
-import { ToolbarModalProps } from "../Toolbar";
-import { Files as Hooks } from "@tapis/tapisui-hooks";
-import { useFilesSelect } from "../../FilesContext";
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, AlertTitle, TextField, Stack } from '@mui/material';
+import { Button } from 'reactstrap';
+import { GenericModal, SubmitWrapper } from '@tapis/tapisui-common';
+import { ToolbarModalProps } from '../Toolbar';
+import { Files as Hooks } from '@tapis/tapisui-hooks';
+import { useFilesSelect } from '../../FilesContext';
 
 const DEFAULT_ALLOWED_USES = 1;
 const DEFAULT_VALID_SECONDS = 3600; // 1 hour
 
 const ShareModal: React.FC<ToolbarModalProps> = ({
   toggle,
-  systemId = "",
-  path = "/",
+  systemId = '',
+  path = '/',
 }) => {
   const { selectedFiles, unselect } = useFilesSelect();
   const { create, isLoading, isError, error, isSuccess, data, reset } =
@@ -22,18 +22,18 @@ const ShareModal: React.FC<ToolbarModalProps> = ({
   const [validSeconds, setValidSeconds] = useState<number>(
     DEFAULT_VALID_SECONDS
   );
-  const [redeemUrl, setRedeemUrl] = useState<string>("");
-  const [copyStatus, setCopyStatus] = useState<"idle" | "success" | "error">(
-    "idle"
+  const [redeemUrl, setRedeemUrl] = useState<string>('');
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'success' | 'error'>(
+    'idle'
   );
 
   const selected = selectedFiles[0];
-  const isDir = selected?.type === "dir";
+  const isDir = selected?.type === 'dir';
   const isMultipleSelection = selectedFiles.length > 1;
 
   const description = useMemo(() => {
-    if (!selected) return "";
-    const kind = isDir ? "folder" : "file";
+    if (!selected) return '';
+    const kind = isDir ? 'folder' : 'file';
     return `You are creating a shareable link for the ${kind} "${selected.name}".`;
   }, [selected, isDir]);
 
@@ -41,14 +41,14 @@ const ShareModal: React.FC<ToolbarModalProps> = ({
     if (data?.result?.redeemUrl) {
       // Add download parameter to force download instead of display
       const url = new URL(data.result.redeemUrl);
-      url.searchParams.set("download", "true");
+      url.searchParams.set('download', 'true');
       setRedeemUrl(url.toString());
     }
   }, [data]);
 
   const onGenerate = useCallback(() => {
     if (!selected) return;
-    setRedeemUrl("");
+    setRedeemUrl('');
     create(
       {
         systemId,
@@ -63,10 +63,10 @@ const ShareModal: React.FC<ToolbarModalProps> = ({
           if (resp.result?.redeemUrl) {
             // Add download parameter to force download instead of display
             const url = new URL(resp.result.redeemUrl);
-            url.searchParams.set("download", "true");
+            url.searchParams.set('download', 'true');
             setRedeemUrl(url.toString());
           } else {
-            setRedeemUrl("");
+            setRedeemUrl('');
           }
         },
       }
@@ -75,29 +75,29 @@ const ShareModal: React.FC<ToolbarModalProps> = ({
 
   const onClose = useCallback(() => {
     reset();
-    setRedeemUrl("");
-    setCopyStatus("idle");
+    setRedeemUrl('');
+    setCopyStatus('idle');
     unselect(selectedFiles);
     toggle();
   }, [reset, toggle, unselect, selectedFiles]);
 
   const handleCopyToClipboard = useCallback(async () => {
     if (!redeemUrl) {
-      setCopyStatus("error");
+      setCopyStatus('error');
       return;
     }
 
     try {
       await navigator.clipboard.writeText(redeemUrl);
-      setCopyStatus("success");
+      setCopyStatus('success');
     } catch (error) {
-      console.error("Error copying to clipboard:", error);
-      setCopyStatus("error");
+      console.error('Error copying to clipboard:', error);
+      setCopyStatus('error');
     }
 
     // Reset status after 2 seconds
     setTimeout(() => {
-      setCopyStatus("idle");
+      setCopyStatus('idle');
     }, 2000);
   }, [redeemUrl]);
 
@@ -105,7 +105,7 @@ const ShareModal: React.FC<ToolbarModalProps> = ({
     <GenericModal
       size="lg"
       toggle={onClose}
-      title={"Share via PostIt"}
+      title={'Share via PostIt'}
       body={
         <div>
           {isError && error && (
@@ -145,11 +145,11 @@ const ShareModal: React.FC<ToolbarModalProps> = ({
               inputProps={{ min: 1 }}
             />
           </Stack>
-          <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
             <SubmitWrapper
               isLoading={isLoading}
               error={null}
-              success={redeemUrl ? "Link created" : undefined}
+              success={redeemUrl ? 'Link created' : undefined}
             >
               <Button
                 color="primary"
@@ -164,25 +164,25 @@ const ShareModal: React.FC<ToolbarModalProps> = ({
                 <div className="input-group-prepend">
                   <Button
                     color={
-                      copyStatus === "success"
-                        ? "success"
-                        : copyStatus === "error"
-                        ? "danger"
-                        : "secondary"
+                      copyStatus === 'success'
+                        ? 'success'
+                        : copyStatus === 'error'
+                        ? 'danger'
+                        : 'secondary'
                     }
                     onClick={handleCopyToClipboard}
                     disabled={!redeemUrl}
                     type="button"
                     style={{
-                      minWidth: "80px",
-                      transition: "all 0.2s ease",
+                      minWidth: '80px',
+                      transition: 'all 0.2s ease',
                     }}
                   >
-                    {copyStatus === "success"
-                      ? "✓ Copied!"
-                      : copyStatus === "error"
-                      ? "✗ Failed"
-                      : "Copy"}
+                    {copyStatus === 'success'
+                      ? '✓ Copied!'
+                      : copyStatus === 'error'
+                      ? '✗ Failed'
+                      : 'Copy'}
                   </Button>
                 </div>
                 <input
@@ -192,8 +192,8 @@ const ShareModal: React.FC<ToolbarModalProps> = ({
                   placeholder="Shareable link will appear here"
                   readOnly
                   style={{
-                    backgroundColor: "#f8f9fa",
-                    cursor: "text",
+                    backgroundColor: '#f8f9fa',
+                    cursor: 'text',
                   }}
                 />
               </div>

--- a/src/app/Files/_components/Toolbar/ShareModal/index.ts
+++ b/src/app/Files/_components/Toolbar/ShareModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ShareModal";

--- a/src/app/Files/_components/Toolbar/ShareModal/index.ts
+++ b/src/app/Files/_components/Toolbar/ShareModal/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ShareModal";
+export { default } from './ShareModal';

--- a/src/app/Files/_components/Toolbar/Toolbar.tsx
+++ b/src/app/Files/_components/Toolbar/Toolbar.tsx
@@ -178,7 +178,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
               <ToolbarButton
                 text="Share"
                 icon="link"
-                disabled={selectedFiles.length === 0}
+                disabled={selectedFiles.length !== 1}
                 onClick={() => setModal("share")}
                 aria-label="Share link"
               />

--- a/src/app/Files/_components/Toolbar/Toolbar.tsx
+++ b/src/app/Files/_components/Toolbar/Toolbar.tsx
@@ -1,24 +1,25 @@
-import { Files, Systems } from '@tapis/tapis-typescript';
-import React, { useState, useCallback } from 'react';
-import { Button } from 'reactstrap';
-import { Icon, QueryWrapper } from '@tapis/tapisui-common';
-import styles from './Toolbar.module.scss';
-import CreateDirModal from './CreateDirModal';
-import MoveCopyModal from './MoveCopyModal';
-import RenameModal from './RenameModal';
-import UploadModal from './UploadModal';
-import PermissionsModal from './PermissionsModal';
-import DeleteModal from './DeleteModal';
-import CreatePostitModal from './CreatePostitModal';
-import TransferModal from './TransferModal';
-import { useLocation } from 'react-router-dom';
-import { useFilesSelect } from '../FilesContext';
+import { Files, Systems } from "@tapis/tapis-typescript";
+import React, { useState, useCallback } from "react";
+import { Button } from "reactstrap";
+import { Icon, QueryWrapper } from "@tapis/tapisui-common";
+import styles from "./Toolbar.module.scss";
+import CreateDirModal from "./CreateDirModal";
+import MoveCopyModal from "./MoveCopyModal";
+import RenameModal from "./RenameModal";
+import UploadModal from "./UploadModal";
+import PermissionsModal from "./PermissionsModal";
+import DeleteModal from "./DeleteModal";
+import CreatePostitModal from "./CreatePostitModal";
+import TransferModal from "./TransferModal";
+import ShareModal from "./ShareModal";
+import { useLocation } from "react-router-dom";
+import { useFilesSelect } from "../FilesContext";
 import {
   Files as FilesHooks,
   Systems as SystemsHooks,
-} from '@tapis/tapisui-hooks';
-import { useNotifications } from 'app/_components/Notifications';
-import { Alert, AlertTitle } from '@mui/material';
+} from "@tapis/tapisui-hooks";
+import { useNotifications } from "app/_components/Notifications";
+import { Alert, AlertTitle } from "@mui/material";
 
 type ToolbarButtonProps = {
   text: string;
@@ -45,7 +46,7 @@ export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
       <Button
         disabled={disabled}
         onClick={onClick}
-        className={styles['toolbar-btn']}
+        className={styles["toolbar-btn"]}
         {...rest}
       >
         <Icon name={icon}></Icon>
@@ -56,15 +57,16 @@ export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
 };
 
 type Op =
-  | 'view'
-  | 'download'
-  | 'upload'
-  | 'copy'
-  | 'rename'
-  | 'move'
-  | 'folder'
-  | 'delete'
-  | 'transfers';
+  | "view"
+  | "share"
+  | "download"
+  | "upload"
+  | "copy"
+  | "rename"
+  | "move"
+  | "folder"
+  | "delete"
+  | "transfers";
 
 type ToolbarProps = {
   systemId: string;
@@ -97,7 +99,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
     isSuccess,
   } = SystemsHooks.useDetails({
     systemId,
-    select: 'allAttributes',
+    select: "allAttributes",
   });
 
   const system = systemData?.result ?? undefined;
@@ -135,25 +137,25 @@ const Toolbar: React.FC<ToolbarProps> = ({
     selectedFiles.forEach((file) => {
       const params: FilesHooks.DownloadStreamParams = {
         systemId,
-        path: file.path ?? '',
-        destination: file.name ?? 'tapisfile',
+        path: file.path ?? "",
+        destination: file.name ?? "tapisfile",
       };
-      const isZip = file.type === 'dir';
+      const isZip = file.type === "dir";
       if (isZip) {
         params.zip = true;
         params.destination = `${params.destination}.zip`;
-        add({ icon: 'data-files', message: `Preparing download` });
+        add({ icon: "data-files", message: `Preparing download` });
         params.onStart = (response: Response) => {
-          add({ icon: 'data-files', message: `Starting download` });
+          add({ icon: "data-files", message: `Starting download` });
         };
       }
       download(params, {
         onError: isZip
           ? () => {
               add({
-                icon: 'data-files',
+                icon: "data-files",
                 message: `Download failed`,
-                status: 'ERROR',
+                status: "ERROR",
               });
             }
           : undefined,
@@ -170,9 +172,18 @@ const Toolbar: React.FC<ToolbarProps> = ({
       error={[error, errorPermissions]}
     >
       <div id="file-operation-toolbar">
-        {pathname !== '/files' && (
-          <div className={styles['toolbar-wrapper']}>
-            {show('view', buttons) && (
+        {pathname !== "/files" && (
+          <div className={styles["toolbar-wrapper"]}>
+            {show("share", buttons) && (
+              <ToolbarButton
+                text="Share"
+                icon="link"
+                disabled={selectedFiles.length === 0}
+                onClick={() => setModal("share")}
+                aria-label="Share link"
+              />
+            )}
+            {show("view", buttons) && (
               <ToolbarButton
                 text="View"
                 icon="file"
@@ -180,40 +191,40 @@ const Toolbar: React.FC<ToolbarProps> = ({
                   selectedFiles.length !== 1 ||
                   selectedFiles[0].type !== Files.FileTypeEnum.File
                 }
-                onClick={() => setModal('postit')}
+                onClick={() => setModal("postit")}
                 aria-label="View file"
               />
             )}
-            {show('rename', buttons) && (
+            {show("rename", buttons) && (
               <ToolbarButton
                 text="Rename"
                 icon="rename"
                 disabled={
                   selectedFiles.length !== 1 || !canModify(system, permission)
                 }
-                onClick={() => setModal('rename')}
+                onClick={() => setModal("rename")}
                 aria-label="Rename"
               />
             )}
-            {show('move', buttons) && (
+            {show("move", buttons) && (
               <ToolbarButton
                 text="Move"
                 icon="move"
                 disabled={
                   selectedFiles.length !== 1 || !canModify(system, permission)
                 }
-                onClick={() => setModal('move')}
+                onClick={() => setModal("move")}
                 aria-label="Move"
               />
             )}
-            {show('copy', buttons) && (
+            {show("copy", buttons) && (
               <ToolbarButton
                 text="Copy"
                 icon="copy"
                 disabled={
                   selectedFiles.length === 0 || !canModify(system, permission)
                 }
-                onClick={() => setModal('copy')}
+                onClick={() => setModal("copy")}
                 aria-label="Copy"
               />
             )}
@@ -225,15 +236,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
                   onClick={() => setModal('permissions')}
                 />
               */}
-            {show('transfers', buttons) && (
+            {show("transfers", buttons) && (
               <ToolbarButton
                 text="Transfers"
                 icon="globe"
                 disabled={false}
-                onClick={() => setModal('transfer')}
+                onClick={() => setModal("transfer")}
               />
             )}
-            {show('download', buttons) && (
+            {show("download", buttons) && (
               <ToolbarButton
                 text="Download"
                 icon="download"
@@ -242,45 +253,45 @@ const Toolbar: React.FC<ToolbarProps> = ({
                 aria-label="Download"
               />
             )}
-            {show('upload', buttons) && (
+            {show("upload", buttons) && (
               <ToolbarButton
                 text="Upload"
                 icon="upload"
                 disabled={!canModify(system, permission)}
                 onClick={() => {
-                  setModal('upload');
+                  setModal("upload");
                 }}
                 aria-label="Upload"
               />
             )}
-            {show('folder', buttons) && (
+            {show("folder", buttons) && (
               <ToolbarButton
                 text="Folder"
                 icon="add"
                 disabled={!canModify(system, permission)}
-                onClick={() => setModal('createdir')}
+                onClick={() => setModal("createdir")}
                 aria-label="Add"
               />
             )}
-            {show('delete', buttons) && (
+            {show("delete", buttons) && (
               <ToolbarButton
                 text="Delete"
                 icon="trash"
                 disabled={
                   selectedFiles.length !== 1 || !canModify(system, permission)
                 }
-                onClick={() => setModal('delete')}
+                onClick={() => setModal("delete")}
                 aria-label="Delete"
               />
             )}
-            {modal === 'createdir' && (
+            {modal === "createdir" && (
               <CreateDirModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === 'copy' && (
+            {modal === "copy" && (
               <MoveCopyModal
                 toggle={toggle}
                 systemId={systemId}
@@ -288,7 +299,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
                 operation={Files.MoveCopyRequestOperationEnum.Copy}
               />
             )}
-            {modal === 'move' && (
+            {modal === "move" && (
               <MoveCopyModal
                 toggle={toggle}
                 systemId={systemId}
@@ -296,43 +307,50 @@ const Toolbar: React.FC<ToolbarProps> = ({
                 operation={Files.MoveCopyRequestOperationEnum.Move}
               />
             )}
-            {modal === 'rename' && (
+            {modal === "rename" && (
               <RenameModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === 'transfer' && (
+            {modal === "transfer" && (
               <TransferModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === 'upload' && (
+            {modal === "upload" && (
               <UploadModal
                 toggle={toggle}
                 path={currentPath}
                 systemId={systemId}
               />
             )}
-            {modal === 'permissions' && (
+            {modal === "permissions" && (
               <PermissionsModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === 'delete' && (
+            {modal === "delete" && (
               <DeleteModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === 'postit' && (
+            {modal === "postit" && (
               <CreatePostitModal
+                toggle={toggle}
+                systemId={systemId}
+                path={currentPath}
+              />
+            )}
+            {modal === "share" && (
+              <ShareModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}

--- a/src/app/Files/_components/Toolbar/Toolbar.tsx
+++ b/src/app/Files/_components/Toolbar/Toolbar.tsx
@@ -1,25 +1,25 @@
-import { Files, Systems } from "@tapis/tapis-typescript";
-import React, { useState, useCallback } from "react";
-import { Button } from "reactstrap";
-import { Icon, QueryWrapper } from "@tapis/tapisui-common";
-import styles from "./Toolbar.module.scss";
-import CreateDirModal from "./CreateDirModal";
-import MoveCopyModal from "./MoveCopyModal";
-import RenameModal from "./RenameModal";
-import UploadModal from "./UploadModal";
-import PermissionsModal from "./PermissionsModal";
-import DeleteModal from "./DeleteModal";
-import CreatePostitModal from "./CreatePostitModal";
-import TransferModal from "./TransferModal";
-import ShareModal from "./ShareModal";
-import { useLocation } from "react-router-dom";
-import { useFilesSelect } from "../FilesContext";
+import { Files, Systems } from '@tapis/tapis-typescript';
+import React, { useState, useCallback } from 'react';
+import { Button } from 'reactstrap';
+import { Icon, QueryWrapper } from '@tapis/tapisui-common';
+import styles from './Toolbar.module.scss';
+import CreateDirModal from './CreateDirModal';
+import MoveCopyModal from './MoveCopyModal';
+import RenameModal from './RenameModal';
+import UploadModal from './UploadModal';
+import PermissionsModal from './PermissionsModal';
+import DeleteModal from './DeleteModal';
+import CreatePostitModal from './CreatePostitModal';
+import TransferModal from './TransferModal';
+import ShareModal from './ShareModal';
+import { useLocation } from 'react-router-dom';
+import { useFilesSelect } from '../FilesContext';
 import {
   Files as FilesHooks,
   Systems as SystemsHooks,
-} from "@tapis/tapisui-hooks";
-import { useNotifications } from "app/_components/Notifications";
-import { Alert, AlertTitle } from "@mui/material";
+} from '@tapis/tapisui-hooks';
+import { useNotifications } from 'app/_components/Notifications';
+import { Alert, AlertTitle } from '@mui/material';
 
 type ToolbarButtonProps = {
   text: string;
@@ -46,7 +46,7 @@ export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
       <Button
         disabled={disabled}
         onClick={onClick}
-        className={styles["toolbar-btn"]}
+        className={styles['toolbar-btn']}
         {...rest}
       >
         <Icon name={icon}></Icon>
@@ -57,16 +57,16 @@ export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
 };
 
 type Op =
-  | "view"
-  | "share"
-  | "download"
-  | "upload"
-  | "copy"
-  | "rename"
-  | "move"
-  | "folder"
-  | "delete"
-  | "transfers";
+  | 'view'
+  | 'share'
+  | 'download'
+  | 'upload'
+  | 'copy'
+  | 'rename'
+  | 'move'
+  | 'folder'
+  | 'delete'
+  | 'transfers';
 
 type ToolbarProps = {
   systemId: string;
@@ -99,7 +99,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
     isSuccess,
   } = SystemsHooks.useDetails({
     systemId,
-    select: "allAttributes",
+    select: 'allAttributes',
   });
 
   const system = systemData?.result ?? undefined;
@@ -137,25 +137,25 @@ const Toolbar: React.FC<ToolbarProps> = ({
     selectedFiles.forEach((file) => {
       const params: FilesHooks.DownloadStreamParams = {
         systemId,
-        path: file.path ?? "",
-        destination: file.name ?? "tapisfile",
+        path: file.path ?? '',
+        destination: file.name ?? 'tapisfile',
       };
-      const isZip = file.type === "dir";
+      const isZip = file.type === 'dir';
       if (isZip) {
         params.zip = true;
         params.destination = `${params.destination}.zip`;
-        add({ icon: "data-files", message: `Preparing download` });
+        add({ icon: 'data-files', message: `Preparing download` });
         params.onStart = (response: Response) => {
-          add({ icon: "data-files", message: `Starting download` });
+          add({ icon: 'data-files', message: `Starting download` });
         };
       }
       download(params, {
         onError: isZip
           ? () => {
               add({
-                icon: "data-files",
+                icon: 'data-files',
                 message: `Download failed`,
-                status: "ERROR",
+                status: 'ERROR',
               });
             }
           : undefined,
@@ -172,18 +172,18 @@ const Toolbar: React.FC<ToolbarProps> = ({
       error={[error, errorPermissions]}
     >
       <div id="file-operation-toolbar">
-        {pathname !== "/files" && (
-          <div className={styles["toolbar-wrapper"]}>
-            {show("share", buttons) && (
+        {pathname !== '/files' && (
+          <div className={styles['toolbar-wrapper']}>
+            {show('share', buttons) && (
               <ToolbarButton
                 text="Share"
                 icon="link"
                 disabled={selectedFiles.length !== 1}
-                onClick={() => setModal("share")}
+                onClick={() => setModal('share')}
                 aria-label="Share link"
               />
             )}
-            {show("view", buttons) && (
+            {show('view', buttons) && (
               <ToolbarButton
                 text="View"
                 icon="file"
@@ -191,40 +191,40 @@ const Toolbar: React.FC<ToolbarProps> = ({
                   selectedFiles.length !== 1 ||
                   selectedFiles[0].type !== Files.FileTypeEnum.File
                 }
-                onClick={() => setModal("postit")}
+                onClick={() => setModal('postit')}
                 aria-label="View file"
               />
             )}
-            {show("rename", buttons) && (
+            {show('rename', buttons) && (
               <ToolbarButton
                 text="Rename"
                 icon="rename"
                 disabled={
                   selectedFiles.length !== 1 || !canModify(system, permission)
                 }
-                onClick={() => setModal("rename")}
+                onClick={() => setModal('rename')}
                 aria-label="Rename"
               />
             )}
-            {show("move", buttons) && (
+            {show('move', buttons) && (
               <ToolbarButton
                 text="Move"
                 icon="move"
                 disabled={
                   selectedFiles.length !== 1 || !canModify(system, permission)
                 }
-                onClick={() => setModal("move")}
+                onClick={() => setModal('move')}
                 aria-label="Move"
               />
             )}
-            {show("copy", buttons) && (
+            {show('copy', buttons) && (
               <ToolbarButton
                 text="Copy"
                 icon="copy"
                 disabled={
                   selectedFiles.length === 0 || !canModify(system, permission)
                 }
-                onClick={() => setModal("copy")}
+                onClick={() => setModal('copy')}
                 aria-label="Copy"
               />
             )}
@@ -236,15 +236,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
                   onClick={() => setModal('permissions')}
                 />
               */}
-            {show("transfers", buttons) && (
+            {show('transfers', buttons) && (
               <ToolbarButton
                 text="Transfers"
                 icon="globe"
                 disabled={false}
-                onClick={() => setModal("transfer")}
+                onClick={() => setModal('transfer')}
               />
             )}
-            {show("download", buttons) && (
+            {show('download', buttons) && (
               <ToolbarButton
                 text="Download"
                 icon="download"
@@ -253,45 +253,45 @@ const Toolbar: React.FC<ToolbarProps> = ({
                 aria-label="Download"
               />
             )}
-            {show("upload", buttons) && (
+            {show('upload', buttons) && (
               <ToolbarButton
                 text="Upload"
                 icon="upload"
                 disabled={!canModify(system, permission)}
                 onClick={() => {
-                  setModal("upload");
+                  setModal('upload');
                 }}
                 aria-label="Upload"
               />
             )}
-            {show("folder", buttons) && (
+            {show('folder', buttons) && (
               <ToolbarButton
                 text="Folder"
                 icon="add"
                 disabled={!canModify(system, permission)}
-                onClick={() => setModal("createdir")}
+                onClick={() => setModal('createdir')}
                 aria-label="Add"
               />
             )}
-            {show("delete", buttons) && (
+            {show('delete', buttons) && (
               <ToolbarButton
                 text="Delete"
                 icon="trash"
                 disabled={
                   selectedFiles.length !== 1 || !canModify(system, permission)
                 }
-                onClick={() => setModal("delete")}
+                onClick={() => setModal('delete')}
                 aria-label="Delete"
               />
             )}
-            {modal === "createdir" && (
+            {modal === 'createdir' && (
               <CreateDirModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === "copy" && (
+            {modal === 'copy' && (
               <MoveCopyModal
                 toggle={toggle}
                 systemId={systemId}
@@ -299,7 +299,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
                 operation={Files.MoveCopyRequestOperationEnum.Copy}
               />
             )}
-            {modal === "move" && (
+            {modal === 'move' && (
               <MoveCopyModal
                 toggle={toggle}
                 systemId={systemId}
@@ -307,49 +307,49 @@ const Toolbar: React.FC<ToolbarProps> = ({
                 operation={Files.MoveCopyRequestOperationEnum.Move}
               />
             )}
-            {modal === "rename" && (
+            {modal === 'rename' && (
               <RenameModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === "transfer" && (
+            {modal === 'transfer' && (
               <TransferModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === "upload" && (
+            {modal === 'upload' && (
               <UploadModal
                 toggle={toggle}
                 path={currentPath}
                 systemId={systemId}
               />
             )}
-            {modal === "permissions" && (
+            {modal === 'permissions' && (
               <PermissionsModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === "delete" && (
+            {modal === 'delete' && (
               <DeleteModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === "postit" && (
+            {modal === 'postit' && (
               <CreatePostitModal
                 toggle={toggle}
                 systemId={systemId}
                 path={currentPath}
               />
             )}
-            {modal === "share" && (
+            {modal === 'share' && (
               <ShareModal
                 toggle={toggle}
                 systemId={systemId}


### PR DESCRIPTION
## Overview:
Add a Share button in file browser for non-authenticated users to download files/folders

## Related Github Issues:
#468 

## Summary of Changes:
1. Added a ShareModal where users can specify allowed uses and valid seconds, and when users click 'Generate Link', the modal will display a shareable link. The user can easily click the Copy button to copy the link to clipboard
<img width="799" height="230" alt="image" src="https://github.com/user-attachments/assets/30e778ec-9f56-44f0-9598-f940b8a3359b" />
<img width="794" height="299" alt="image" src="https://github.com/user-attachments/assets/5bdf5a01-5d37-4936-b49b-c1435d196d8f" />

2. Display the Share button in the Toolbar

<img width="878" height="355" alt="image" src="https://github.com/user-attachments/assets/a4730016-efbc-412a-869c-06cca7538721" />

## Testing Steps:
1. Select one file or directory from Files
2. Click the 'Share' button
3. Specify the allowed uses and valid seconds
4. Click the 'Generate Link' button
5. Click the 'Copy' button
6. The link should allow non-authenticated users to download the shared files (up to allowed uses times)