### PR TITLE
Add Food Systems portal pages to Icicle extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ web_modules/
 # dotenv environment variables file
 .env
 .env.test
+agents.md
+AGENTS.md
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/packages/icicle-tapisui-extension/.gitignore
+++ b/packages/icicle-tapisui-extension/.gitignore
@@ -1,2 +1,4 @@
 dist
 node_modules
+agents.md
+.*agents.md

--- a/packages/icicle-tapisui-extension/src/index.ts
+++ b/packages/icicle-tapisui-extension/src/index.ts
@@ -15,6 +15,9 @@ import {
   DigitalAgOpenPASS,
   ComponentCatalog,
   Harvest,
+  FoodFlowPortal,
+  FEAST,
+  FoodSecuritySandbox,
 } from './pages';
 
 const extension = createExtension({
@@ -38,6 +41,9 @@ const extension = createExtension({
     'jupyter-lab',
     'analytics',
     'training-catalog',
+    'food-flow-portal',
+    'feast',
+    'food-security-sandbox',
     'component-catalog',
     'ckn-dashboard',
     'openpass',
@@ -109,6 +115,27 @@ extension.registerService({
   sidebarDisplayName: 'Training Catalog',
   iconName: 'globe',
   component: TrainingCatalog,
+});
+
+extension.registerService({
+  id: 'food-flow-portal',
+  sidebarDisplayName: 'Food Flow Portal',
+  iconName: 'globe',
+  component: FoodFlowPortal,
+});
+
+extension.registerService({
+  id: 'feast',
+  sidebarDisplayName: 'FEAST',
+  iconName: 'globe',
+  component: FEAST,
+});
+
+extension.registerService({
+  id: 'food-security-sandbox',
+  sidebarDisplayName: 'Food Security Sandbox',
+  iconName: 'globe',
+  component: FoodSecuritySandbox,
 });
 
 extension.registerService({

--- a/packages/icicle-tapisui-extension/src/pages/FEAST/FEAST.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/FEAST/FEAST.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SectionHeader } from '@tapis/tapisui-common';
 import { Component } from '@tapis/tapisui-extensions-core';
 
-export const TrainingCatalog: Component = ({ accessToken }) => {
+export const FEAST: Component = ({ accessToken }) => {
   return (
     <div
       style={{
@@ -16,7 +16,8 @@ export const TrainingCatalog: Component = ({ accessToken }) => {
       {accessToken ? (
         <iframe
           style={{ flexGrow: 1, border: 'none' }}
-          src={`https://icicle-ai.github.io/training-catalog/docs/intro`}
+          src="https://feast.pods.icicleai.tapis.io/"
+          title="FEAST"
         />
       ) : (
         <>Invalid JWT. Log out of TapisUI then log back in</>
@@ -25,4 +26,4 @@ export const TrainingCatalog: Component = ({ accessToken }) => {
   );
 };
 
-export default TrainingCatalog;
+export default FEAST;

--- a/packages/icicle-tapisui-extension/src/pages/FEAST/index.ts
+++ b/packages/icicle-tapisui-extension/src/pages/FEAST/index.ts
@@ -1,0 +1,1 @@
+export { default as FEAST } from './FEAST';

--- a/packages/icicle-tapisui-extension/src/pages/FoodFlowPortal/FoodFlowPortal.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/FoodFlowPortal/FoodFlowPortal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SectionHeader } from '@tapis/tapisui-common';
 import { Component } from '@tapis/tapisui-extensions-core';
 
-export const TrainingCatalog: Component = ({ accessToken }) => {
+export const FoodFlowPortal: Component = ({ accessToken }) => {
   return (
     <div
       style={{
@@ -16,7 +16,8 @@ export const TrainingCatalog: Component = ({ accessToken }) => {
       {accessToken ? (
         <iframe
           style={{ flexGrow: 1, border: 'none' }}
-          src={`https://icicle-ai.github.io/training-catalog/docs/intro`}
+          src="https://gnnfoodflowportal.pods.icicleai.tapis.io/"
+          title="Food Flow Portal"
         />
       ) : (
         <>Invalid JWT. Log out of TapisUI then log back in</>
@@ -25,4 +26,4 @@ export const TrainingCatalog: Component = ({ accessToken }) => {
   );
 };
 
-export default TrainingCatalog;
+export default FoodFlowPortal;

--- a/packages/icicle-tapisui-extension/src/pages/FoodFlowPortal/index.ts
+++ b/packages/icicle-tapisui-extension/src/pages/FoodFlowPortal/index.ts
@@ -1,0 +1,1 @@
+export { default as FoodFlowPortal } from './FoodFlowPortal';

--- a/packages/icicle-tapisui-extension/src/pages/FoodSecuritySandbox/FoodSecuritySandbox.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/FoodSecuritySandbox/FoodSecuritySandbox.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SectionHeader } from '@tapis/tapisui-common';
 import { Component } from '@tapis/tapisui-extensions-core';
 
-export const TrainingCatalog: Component = ({ accessToken }) => {
+export const FoodSecuritySandbox: Component = ({ accessToken }) => {
   return (
     <div
       style={{
@@ -16,7 +16,8 @@ export const TrainingCatalog: Component = ({ accessToken }) => {
       {accessToken ? (
         <iframe
           style={{ flexGrow: 1, border: 'none' }}
-          src={`https://icicle-ai.github.io/training-catalog/docs/intro`}
+          src="https://fss.pods.icicleai.tapis.io/"
+          title="Food Security Sandbox"
         />
       ) : (
         <>Invalid JWT. Log out of TapisUI then log back in</>
@@ -25,4 +26,4 @@ export const TrainingCatalog: Component = ({ accessToken }) => {
   );
 };
 
-export default TrainingCatalog;
+export default FoodSecuritySandbox;

--- a/packages/icicle-tapisui-extension/src/pages/FoodSecuritySandbox/index.ts
+++ b/packages/icicle-tapisui-extension/src/pages/FoodSecuritySandbox/index.ts
@@ -1,0 +1,1 @@
+export { default as FoodSecuritySandbox } from './FoodSecuritySandbox';

--- a/packages/icicle-tapisui-extension/src/pages/index.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/index.tsx
@@ -10,3 +10,6 @@ export { CKNDashboard } from './CKNDashboard';
 export { CatalogAnalytics } from './CatalogAnalytics';
 export { ComponentCatalog } from './ComponentCatalog';
 export { Harvest } from './Harvest';
+export { FoodFlowPortal } from './FoodFlowPortal';
+export { FEAST } from './FEAST';
+export { FoodSecuritySandbox } from './FoodSecuritySandbox';


### PR DESCRIPTION
  ## Overview:
  Add three Food Systems portal pages (Food Flow Portal, FEAST, Food Security Sandbox) to the Icicle Tapis UI extension
  and register them in the sidebar.

  ## Related Github Issues:
  - https://github.com/tapis-project/tapis-ui/issues/509

  ## Summary of Changes:
  - Added new portal page components under the Icicle extension.
  - Registered new routes/services in the Icicle extension sidebar.

  ## Testing Steps:
  1. pnpm test
  2. pnpm lint
  3. pnpm prettier
