### PR TITLE
Remove stale ICICLE flags and restore sidebar layout

### DIFF
--- a/src/app/Dashboard/_components/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/_components/Dashboard/Dashboard.tsx
@@ -127,7 +127,7 @@ const Dashboard: React.FC = () => {
           <>
             <Card
               className={`${styles.card} ${styles['welcome-card']} ${styles['card-wide']}`}
-              style={isIcicle ? undefined : { width: '51rem' }}
+              style={{ width: '51rem' }}
             >
               <CardHeader>
                 <div className={styles['card-header']}>
@@ -137,190 +137,50 @@ const Dashboard: React.FC = () => {
                       className="dashboard__card-icon"
                     />
                   </div>
-                  <div>
-                    {isIcicle ? 'ICICLE AI TapisUI' : 'Welcome to TapisUI!'}
-                  </div>
+                  <div>Welcome to TapisUI!</div>
                 </div>
               </CardHeader>
               <CardBody>
                 <CardText>
-                  {isIcicle ? (
-                    <>
-                      Led by The Ohio State University, NSF ICICLE is building
-                      next-generation cyberinfrastructure to democratize AI and
-                      make it accessible across domains. Through integrated
-                      plug-and-play AI and interdisciplinary communities, ICICLE
-                      advances AI and CI to address societal challenges. The
-                      components below highlight ICICLE&apos;s work across three
-                      use-inspired domains. Learn more at{' '}
-                      <a
-                        href="https://icicle.ai"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        icicle.ai
-                      </a>
-                      .
-                    </>
-                  ) : (
-                    <>
-                      TapisUI is a React + TypeScript web application that
-                      provides a unified, user-friendly interface which provides
-                      validated, up-to-date, and automated access to all Tapis
-                      Services. TapisUI is designed for researchers, students,
-                      and developers who want to manage computational resources,
-                      launch jobs, deploy containers, and interface with
-                      cyberinfrastructure.
-                    </>
-                  )}
+                  TapisUI is a React + TypeScript web application that provides
+                  a unified, user-friendly interface which provides validated,
+                  up-to-date, and automated access to all Tapis Services.
+                  TapisUI is designed for researchers, students, and developers
+                  who want to manage computational resources, launch jobs,
+                  deploy containers, and interface with cyberinfrastructure.
                 </CardText>
-                {isIcicle && (
-                  <div
-                    style={{
-                      display: 'flex',
-                      gap: '1rem',
-                      flexWrap: 'nowrap',
-                      marginTop: '1rem',
-                    }}
-                  >
-                    <Card className={styles.card} style={{ marginRight: 0 }}>
-                      <CardHeader>
-                        <div className={styles['card-header']}>
-                          <div>
-                            <Icon
-                              name="simulation"
-                              className="dashboard__card-icon"
-                            />
-                          </div>
-                          <div>Animal Ecology</div>
-                        </div>
-                      </CardHeader>
-                      <CardBody>
-                        <CardText>
-                          Explore modeling and simulation tools tailored for
-                          animal ecology workflows.
-                        </CardText>
-                        <div style={{ marginTop: '0.5rem' }}>
-                          <Link to="/ml-edge">ML Edge</Link>
-                        </div>
-                        <div style={{ fontSize: '0.85rem' }}>
-                          Configure experiments, models, and algorithm settings
-                          in a graphical interface for edge-to-center studies.
-                        </div>
-                        <div>
-                          <Link to="/openpass">OpenPASS</Link>
-                        </div>
-                        <div style={{ fontSize: '0.85rem' }}>
-                          A distributed drone platform that captures and
-                          analyzes aerial imagery for precision agriculture and
-                          field management.
-                        </div>
-                      </CardBody>
-                    </Card>
-                    <Card className={styles.card} style={{ marginRight: 0 }}>
-                      <CardHeader>
-                        <div className={styles['card-header']}>
-                          <div>
-                            <Icon
-                              name="globe"
-                              className="dashboard__card-icon"
-                            />
-                          </div>
-                          <div>Digital Agriculture</div>
-                        </div>
-                      </CardHeader>
-                      <CardBody>
-                        <CardText>
-                          Connect to tools that support digital agriculture data
-                          collection and analysis.
-                        </CardText>
-                        <div>
-                          <Link to="/harvest">Harvest</Link>
-                        </div>
-                        <div style={{ fontSize: '0.85rem' }}>
-                          Build pipelines to preprocess data, train models on
-                          HPC, run inference, and visualize field insights.
-                        </div>
-                      </CardBody>
-                    </Card>
-                    <Card className={styles.card} style={{ marginRight: 0 }}>
-                      <CardHeader>
-                        <div className={styles['card-header']}>
-                          <div>
-                            <Icon
-                              name="globe"
-                              className="dashboard__card-icon"
-                            />
-                          </div>
-                          <div>Food Systems</div>
-                        </div>
-                      </CardHeader>
-                      <CardBody>
-                        <CardText>
-                          Access ICICLE food systems portals and sandboxes for
-                          exploration and analysis.
-                        </CardText>
-                        <div>
-                          <Link to="/food-flow-portal">Food Flow Portal</Link>
-                        </div>
-                        <div style={{ fontSize: '0.85rem' }}>
-                          Interactive map to explore GNN FoodFlow results and
-                          download filtered data.
-                        </div>
-                        <div>
-                          <Link to="/feast">FEAST</Link>
-                        </div>
-                        <div style={{ fontSize: '0.85rem' }}>
-                          Simulate how food retail changes affect household
-                          access and evaluate equity strategies.
-                        </div>
-                        <div>
-                          <Link to="/food-security-sandbox">
-                            Food Security Sandbox
-                          </Link>
-                        </div>
-                        <div style={{ fontSize: '0.85rem' }}>
-                          Collaborative ML platform for agricultural data with
-                          privacy-preserving training and risk analysis.
-                        </div>
-                      </CardBody>
-                    </Card>
+                <div className={styles['welcome-links']}>
+                  <div>
+                    📚{' '}
+                    <a
+                      href="https://tapis.readthedocs.io/en/latest/technical/tapisui.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      TapisUI & Tapis Documentation
+                    </a>
                   </div>
-                )}
-                {!isIcicle && (
-                  <div className={styles['welcome-links']}>
-                    <div>
-                      📚{' '}
-                      <a
-                        href="https://tapis.readthedocs.io/en/latest/technical/tapisui.html"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        TapisUI & Tapis Documentation
-                      </a>
-                    </div>
-                    <div>
-                      🔧{' '}
-                      <a
-                        href="https://tapis-project.github.io/live-docs/?service=Systems"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        Live Tapis Documentation
-                      </a>
-                    </div>
-                    <div>
-                      💻{' '}
-                      <a
-                        href="https://github.com/tapis-project/tapis-ui"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        GitHub Repository
-                      </a>
-                    </div>
+                  <div>
+                    🔧{' '}
+                    <a
+                      href="https://tapis-project.github.io/live-docs/?service=Systems"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Live Tapis Documentation
+                    </a>
                   </div>
-                )}
+                  <div>
+                    💻{' '}
+                    <a
+                      href="https://github.com/tapis-project/tapis-ui"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      GitHub Repository
+                    </a>
+                  </div>
+                </div>
               </CardBody>
             </Card>
             <DashboardCard

--- a/src/app/_Router/Router.tsx
+++ b/src/app/_Router/Router.tsx
@@ -36,6 +36,9 @@ const Router: React.FC = () => {
           <Dashboard />
         )}
       </Route>
+      <Route exact path="/dashboard">
+        <Dashboard />
+      </Route>
       <Route path="/login">
         <Login />
       </Route>

--- a/src/app/_components/Sidebar/Sidebar.tsx
+++ b/src/app/_components/Sidebar/Sidebar.tsx
@@ -289,7 +289,11 @@ const Sidebar: React.FC = () => {
         {isIcicleExtension &&
           accessToken &&
           renderSidebarItem('/home', 'globe', 'Portal Home(beta)')}
-        {renderSidebarItem('/', 'dashboard', 'Dashboard')}
+        {renderSidebarItem(
+          extensionName === '@icicle/tapisui-extension' ? '/dashboard' : '/',
+          'dashboard',
+          'Dashboard'
+        )}
         {!accessToken && renderSidebarItem('/login', 'user', 'Login')}
         {accessToken && (
           <>


### PR DESCRIPTION
## Overview:

This branch removes leftover ICICLE flags from core src/ and restores the default sidebar layout for all tenants, while keeping the ICICLE portal flow in the extension untouched.

## Related Github Issues:

- https://github.com/tapis-project/tapis-ui/issues/514

## Summary of Changes:
- Removed ICICLE‑specific dashboard content and logic in src/app/Dashboard/ _components/Dashboard/Dashboard.tsx.
- Restored default sidebar layout (no ICICLE‑only styling or bottom pinning) in src/app/_components/Sidebar/Sidebar.tsx and src/app/_components/Sidebar/Sidebar.module.scss.
- Kept ICICLE portal behavior isolated to the extension (no new core tenant‑specific styling).

## Testing Steps:
pnpm test
pnpm lint
pnpm prettier

