### PR TITLE
[3/n] Task/t UI 516 streaming response for chat panel

### DIFF
--- a/src/app/MlHub/services/agents/modelSelectionAgent.ts
+++ b/src/app/MlHub/services/agents/modelSelectionAgent.ts
@@ -2,6 +2,7 @@ import {
   Agent,
   AgentContext,
   AgentResult,
+  AgentStreamHandlers,
   ChatTurn,
 } from 'app/_context/chat/agentTypes';
 import {
@@ -123,7 +124,8 @@ async function callLiteLLM(
   endpoint: string,
   messages: LLMMessage[],
   jwt: string,
-  model: string = 'llama4-17b'
+  model: string = 'llama4-17b',
+  handlers?: AgentStreamHandlers
 ): Promise<string> {
   const token = extractTapisToken(jwt);
   try {
@@ -137,9 +139,75 @@ async function callLiteLLM(
         model,
         messages,
         temperature: 0.2,
+        stream: Boolean(handlers?.onDelta),
       }),
+      signal: handlers?.signal,
     });
     await assertOkResponse(response, LITELLM_SERVICE_NAME);
+
+    if (handlers?.onDelta) {
+      if (!response.body) {
+        throw new Error('LiteLLM API did not return a streaming body');
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder('utf-8');
+      let pending = '';
+      let fullContent = '';
+      let thinkingOpen = false;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        pending += decoder.decode(value, { stream: true });
+        const lines = pending.split('\n');
+        pending = lines.pop() || '';
+
+        for (const lineRaw of lines) {
+          const line = lineRaw.trim();
+          if (!line.startsWith('data: ')) continue;
+          if (line === 'data: [DONE]') continue;
+          try {
+            const chunk = JSON.parse(line.slice(6));
+            const contentDelta: string =
+              chunk?.choices?.[0]?.delta?.content ?? '';
+            const reasoningDelta: string =
+              chunk?.choices?.[0]?.delta?.reasoning_content ?? '';
+            if (reasoningDelta) {
+              if (!thinkingOpen) {
+                thinkingOpen = true;
+                fullContent += '<think>';
+                handlers.onDelta('<think>');
+              }
+              fullContent += reasoningDelta;
+              handlers.onDelta(reasoningDelta);
+            }
+            if (contentDelta) {
+              if (thinkingOpen) {
+                thinkingOpen = false;
+                fullContent += '</think>';
+                handlers.onDelta('</think>');
+              }
+              fullContent += contentDelta;
+              handlers.onDelta(contentDelta);
+            }
+          } catch {
+            // Ignore malformed stream chunks and continue processing.
+          }
+        }
+      }
+
+      if (thinkingOpen) {
+        thinkingOpen = false;
+        fullContent += '</think>';
+        handlers.onDelta('</think>');
+      }
+
+      if (!fullContent) {
+        throw new Error('LiteLLM API returned empty streamed answer');
+      }
+      return fullContent;
+    }
+
     const data = await response.json();
     const content: string = data?.choices?.[0]?.message?.content ?? '';
     if (!content) {
@@ -151,6 +219,38 @@ async function callLiteLLM(
   }
 }
 
+async function prepareModelSelection(
+  history: ChatTurn[],
+  context: AgentContext
+) {
+  const userText = getLastUserMessage(history);
+  const platformMatch = userText.match(/platform\s*:\s*([\w-]+)/i);
+  const platform = platformMatch
+    ? platformMatch[1].toLowerCase()
+    : 'huggingface';
+  const models = await fetchModels(
+    platform,
+    context.mlHubBasePath || context.basePath,
+    context.jwt
+  );
+  const litellmEndpoint =
+    process.env.NODE_ENV === 'development'
+      ? '/api/litellm'
+      : 'https://litellm.pods.tacc.tapis.io';
+  const messages: LLMMessage[] = [
+    { role: 'system', content: buildLLMSystemPrompt() },
+    ...buildPriorMessages(history),
+    { role: 'user', content: buildLLMUserPrompt(userText, platform, models) },
+  ];
+  return { litellmEndpoint, messages, jwt: context.jwt };
+}
+
+function isAbortLikeError(e: unknown): boolean {
+  if (e instanceof DOMException) return e.name === 'AbortError';
+  if (e instanceof Error) return e.name === 'AbortError';
+  return false;
+}
+
 export const ModelSelectionAgent: Agent = {
   id: 'model-selection',
   name: 'Model Selection Agent',
@@ -159,37 +259,47 @@ export const ModelSelectionAgent: Agent = {
     history: ChatTurn[],
     context: AgentContext
   ): Promise<AgentResult> => {
-    const userText = getLastUserMessage(history);
-
-    // Expect platform embedded in the user text for MVP, e.g., "platform: HuggingFace"
-    const platformMatch = userText.match(/platform\s*:\s*([\w-]+)/i);
-    const platform = platformMatch
-      ? platformMatch[1].toLowerCase()
-      : 'huggingface';
-
-    const models = await fetchModels(
-      platform,
-      context.mlHubBasePath || context.basePath,
-      context.jwt
-    );
-
-    const litellmEndpoint =
-      process.env.NODE_ENV === 'development'
-        ? '/api/litellm'
-        : 'https://litellm.pods.tacc.tapis.io';
-
+    const prep = await prepareModelSelection(history, context);
     let llmRaw = '';
     try {
-      const sys = buildLLMSystemPrompt();
-      const usr = buildLLMUserPrompt(userText, platform, models);
-      const messages: LLMMessage[] = [
-        { role: 'system', content: sys },
-        ...buildPriorMessages(history),
-        { role: 'user', content: usr },
-      ];
-      llmRaw = await callLiteLLM(litellmEndpoint, messages, context.jwt);
+      llmRaw = await callLiteLLM(prep.litellmEndpoint, prep.messages, prep.jwt);
     } catch (e) {
       llmRaw = `LiteLLM error: ${formatAgentError(e)}`;
+    }
+
+    return {
+      messages: [
+        {
+          id: `${Date.now()}-assistant-raw`,
+          role: 'assistant',
+          content: llmRaw || 'No response from model.',
+        },
+      ],
+    };
+  },
+  respondStream: async (
+    history: ChatTurn[],
+    context: AgentContext,
+    handlers: AgentStreamHandlers
+  ): Promise<AgentResult> => {
+    const prep = await prepareModelSelection(history, context);
+    let llmRaw = '';
+    try {
+      llmRaw = await callLiteLLM(
+        prep.litellmEndpoint,
+        prep.messages,
+        prep.jwt,
+        'llama4-17b',
+        handlers
+      );
+    } catch (e) {
+      const isAborted = handlers.signal?.aborted || isAbortLikeError(e);
+      if (!isAborted) {
+        llmRaw = `LiteLLM error: ${formatAgentError(e)}`;
+        handlers.onDelta?.(llmRaw);
+      }
+    } finally {
+      handlers.onDone?.();
     }
 
     return {

--- a/src/app/_Layout/Layout.tsx
+++ b/src/app/_Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useContext } from 'react';
+import React, { useState, useEffect, useMemo, useContext, useRef } from 'react';
 import { Router } from 'app/_Router';
 import { NotificationsProvider } from 'app/_components/Notifications';
 import { Link, useHistory, useLocation } from 'react-router-dom';
@@ -39,6 +39,35 @@ import 'app/Jobs/_context/registerJobsChat';
 import 'app/Workflows/_context/registerWorkflowsChat';
 import 'app/Pods/_context/registerPodsChat';
 
+function parseAssistantStream(raw: string) {
+  const thinkStartToken = '<think>';
+  const thinkEndToken = '</think>';
+  let visible = '';
+  let thinking = '';
+  let cursor = 0;
+  let thinkingInProgress = false;
+
+  while (cursor < raw.length) {
+    const start = raw.indexOf(thinkStartToken, cursor);
+    if (start === -1) {
+      visible += raw.slice(cursor);
+      break;
+    }
+    visible += raw.slice(cursor, start);
+    const thinkStart = start + thinkStartToken.length;
+    const end = raw.indexOf(thinkEndToken, thinkStart);
+    if (end === -1) {
+      thinking += raw.slice(thinkStart);
+      thinkingInProgress = true;
+      break;
+    }
+    thinking += raw.slice(thinkStart, end);
+    cursor = end + thinkEndToken.length;
+  }
+
+  return { visible, thinking, thinkingInProgress };
+}
+
 const LayoutContent: React.FC = () => {
   const { claims, pathTenantId, pathSiteId } = useTapisConfig();
   const { extension } = useExtension();
@@ -53,10 +82,26 @@ const LayoutContent: React.FC = () => {
 
   // Chat functionality
   const { isChatOpen, setIsChatOpen, activeChatId } = useContext(ChatContext);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [isSending, setIsSending] = useState(false);
+  const [messagesByChatId, setMessagesByChatId] = useState<
+    Record<string, ChatMessage[]>
+  >({});
+  const [isSendingByChatId, setIsSendingByChatId] = useState<
+    Record<string, boolean>
+  >({});
+  const abortControllersRef = useRef<Record<string, AbortController | null>>(
+    {}
+  );
+  const loadedChatIdsRef = useRef<Set<string>>(new Set());
   const { accessToken, basePath, mlHubBasePath } = useTapisConfig();
   const isAuthenticated = Boolean(accessToken?.access_token);
+
+  useEffect(() => {
+    return () => {
+      Object.values(abortControllersRef.current).forEach((controller) =>
+        controller?.abort()
+      );
+    };
+  }, []);
 
   // Get the current chat configuration
   const chatConfig = useMemo(() => {
@@ -74,18 +119,60 @@ const LayoutContent: React.FC = () => {
     return chatConfig?.storageKey || 'ml-hub-model-chat-messages';
   }, [chatConfig]);
 
+  const updateMessagesForChat = (
+    chatId: string,
+    updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])
+  ) => {
+    setMessagesByChatId((prev) => {
+      const prevMessages = prev[chatId] || [];
+      const nextMessages =
+        typeof updater === 'function' ? updater(prevMessages) : updater;
+      if (typeof window !== 'undefined') {
+        const key = getChatConfig(chatId)?.storageKey;
+        if (key) {
+          if (!nextMessages || nextMessages.length === 0) {
+            try {
+              window.localStorage.removeItem(key);
+            } catch (e) {
+              console.warn('Failed to clear persisted chat messages', e);
+            }
+          } else {
+            const hasActiveStream = nextMessages.some(
+              (m) => m.meta?.stream?.streaming === true
+            );
+            if (!hasActiveStream) {
+              try {
+                window.localStorage.setItem(key, JSON.stringify(nextMessages));
+              } catch (e) {
+                console.warn('Failed to persist chat messages', e);
+              }
+            }
+          }
+        }
+      }
+      return { ...prev, [chatId]: nextMessages };
+    });
+  };
+
+  const setSendingForChat = (chatId: string, isSending: boolean) => {
+    setIsSendingByChatId((prev) => ({ ...prev, [chatId]: isSending }));
+  };
+
   // Load messages when chat ID changes
   useEffect(() => {
     if (typeof window === 'undefined' || !chatConfig) return;
+    if (loadedChatIdsRef.current.has(activeChatId)) return;
+    loadedChatIdsRef.current.add(activeChatId);
     try {
       const raw = window.localStorage.getItem(storageKey);
       if (!raw) {
-        setMessages([]);
+        updateMessagesForChat(activeChatId, []);
         return;
       }
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) {
-        setMessages(
+        updateMessagesForChat(
+          activeChatId,
           parsed.filter(
             (msg) =>
               msg &&
@@ -95,26 +182,16 @@ const LayoutContent: React.FC = () => {
           )
         );
       } else {
-        setMessages([]);
+        updateMessagesForChat(activeChatId, []);
       }
     } catch (error) {
       console.warn('Failed to restore chat messages', error);
-      setMessages([]);
+      updateMessagesForChat(activeChatId, []);
     }
-  }, [storageKey, chatConfig]);
+  }, [storageKey, chatConfig, activeChatId]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      if (!messages || messages.length === 0) {
-        window.localStorage.removeItem(storageKey);
-        return;
-      }
-      window.localStorage.setItem(storageKey, JSON.stringify(messages));
-    } catch (error) {
-      console.warn('Failed to persist chat messages', error);
-    }
-  }, [messages, storageKey]);
+  const activeMessages = messagesByChatId[activeChatId] || [];
+  const activeIsSending = Boolean(isSendingByChatId[activeChatId]);
 
   const handleSend = async (text: string) => {
     if (!chatConfig) {
@@ -122,18 +199,25 @@ const LayoutContent: React.FC = () => {
       return;
     }
 
+    const requestChatId = activeChatId;
     const now = Date.now();
     const userTurn: ChatTurn = {
       id: `${now}-user`,
       role: 'user',
       content: text,
     };
-    const nextHistory: ChatTurn[] = [...messages, userTurn];
-    setMessages([...messages, { ...userTurn, timestamp: now }]);
-    setIsSending(true);
+    const currentMessages = messagesByChatId[requestChatId] || [];
+    const nextHistory: ChatTurn[] = [...currentMessages, userTurn];
+    updateMessagesForChat(requestChatId, [
+      ...currentMessages,
+      { ...userTurn, timestamp: now },
+    ]);
+    setSendingForChat(requestChatId, true);
+    let streamingAssistantMessageId: string | null = null;
+
     try {
       if (!accessToken?.access_token) {
-        setMessages((prev) => [
+        updateMessagesForChat(requestChatId, (prev) => [
           ...prev,
           {
             id: `${Date.now()}-error`,
@@ -145,44 +229,163 @@ const LayoutContent: React.FC = () => {
         return;
       }
 
-      // Get agent context from the chat config
       const agentContext = chatConfig.getAgentContext({
         accessToken,
         basePath,
         mlHubBasePath,
       });
 
-      // Use the agent from the chat config
-      const result = await chatConfig.agent.respond(nextHistory, agentContext);
-      if (result.messages && result.messages.length > 0) {
-        const now = Date.now();
-        setMessages((prev) => [
+      const canStream = typeof chatConfig.agent.respondStream === 'function';
+
+      if (canStream) {
+        const assistantMessageId = `${Date.now()}-assistant-stream`;
+        streamingAssistantMessageId = assistantMessageId;
+        let rawStream = '';
+        const abortController = new AbortController();
+        abortControllersRef.current[requestChatId] = abortController;
+
+        updateMessagesForChat(requestChatId, (prev) => [
           ...prev,
-          ...result.messages.map((msg) => ({ ...msg, timestamp: now })),
+          {
+            id: assistantMessageId,
+            role: 'assistant',
+            content: '',
+            timestamp: Date.now(),
+            meta: {
+              stream: {
+                thinking: '',
+                thinkingInProgress: false,
+                streaming: true,
+              },
+            },
+          },
         ]);
+
+        const flushStreamState = (streaming: boolean) => {
+          const parsed = parseAssistantStream(rawStream);
+          updateMessagesForChat(requestChatId, (prev) =>
+            prev.map((msg) =>
+              msg.id === assistantMessageId
+                ? {
+                    ...msg,
+                    content: parsed.visible,
+                    meta: {
+                      ...msg.meta,
+                      stream: {
+                        thinking: parsed.thinking,
+                        thinkingInProgress: parsed.thinkingInProgress,
+                        streaming,
+                      },
+                    },
+                  }
+                : msg
+            )
+          );
+        };
+
+        await chatConfig.agent.respondStream!(nextHistory, agentContext, {
+          signal: abortController.signal,
+          onDelta: (delta) => {
+            rawStream += delta;
+            flushStreamState(true);
+          },
+          onDone: () => {
+            flushStreamState(false);
+            if (abortControllersRef.current[requestChatId] === abortController) {
+              abortControllersRef.current[requestChatId] = null;
+            }
+          },
+        });
+      } else {
+        const result = await chatConfig.agent.respond(
+          nextHistory,
+          agentContext
+        );
+        if (result.messages && result.messages.length > 0) {
+          const responseTimestamp = Date.now();
+          updateMessagesForChat(requestChatId, (prev) => [
+            ...prev,
+            ...result.messages.map((msg) => ({
+              ...msg,
+              timestamp: responseTimestamp,
+            })),
+          ]);
+        }
       }
     } catch (error) {
+      if ((error as Error)?.name === 'AbortError') {
+        if (streamingAssistantMessageId) {
+          updateMessagesForChat(requestChatId, (prev) =>
+            prev.map((msg) =>
+              msg.id === streamingAssistantMessageId
+                ? {
+                    ...msg,
+                    meta: {
+                      ...msg.meta,
+                      stream: {
+                        ...(msg.meta?.stream ?? {
+                          thinking: '',
+                          thinkingInProgress: false,
+                          streaming: false,
+                        }),
+                        streaming: false,
+                      },
+                    },
+                  }
+                : msg
+            )
+          );
+        }
+        return;
+      }
       console.error('Error sending message:', error);
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `${Date.now()}-error`,
-          role: 'assistant',
-          content:
-            'An error occurred while processing your message. Please try again.',
-          timestamp: Date.now(),
-        },
-      ]);
+      const errorContent =
+        'An error occurred while processing your message. Please try again.';
+      if (streamingAssistantMessageId) {
+        updateMessagesForChat(requestChatId, (prev) =>
+          prev.map((msg) =>
+            msg.id === streamingAssistantMessageId
+              ? {
+                  ...msg,
+                  content: errorContent,
+                  timestamp: Date.now(),
+                  meta: {
+                    ...msg.meta,
+                    stream: {
+                      ...(msg.meta?.stream ?? {
+                        thinking: '',
+                        thinkingInProgress: false,
+                        streaming: false,
+                      }),
+                      streaming: false,
+                    },
+                  },
+                }
+              : msg
+          )
+        );
+      } else {
+        updateMessagesForChat(requestChatId, (prev) => [
+          ...prev,
+          {
+            id: `${Date.now()}-error`,
+            role: 'assistant',
+            content: errorContent,
+            timestamp: Date.now(),
+          },
+        ]);
+      }
     } finally {
-      setIsSending(false);
+      setSendingForChat(requestChatId, false);
     }
   };
 
   const handleClearChat = () => {
-    setMessages([]);
-    if (typeof window !== 'undefined') {
-      window.localStorage.removeItem(storageKey);
-    }
+    const currentChatId = activeChatId;
+    abortControllersRef.current[currentChatId]?.abort();
+    abortControllersRef.current[currentChatId] = null;
+    updateMessagesForChat(currentChatId, []);
+    setSendingForChat(currentChatId, false);
   };
 
   // Set the document title dynamically based on the tenant ID
@@ -226,9 +429,9 @@ const LayoutContent: React.FC = () => {
           open={isChatOpen}
           onClose={() => setIsChatOpen(false)}
           title={chatConfig.title}
-          messages={messages}
+          messages={activeMessages}
           onSend={handleSend}
-          isSending={isSending}
+          isSending={activeIsSending}
           onClearChat={handleClearChat}
           headerExtras={<ChatSelector />}
           emptyStateContent={

--- a/src/app/_Layout/Layout.tsx
+++ b/src/app/_Layout/Layout.tsx
@@ -291,7 +291,9 @@ const LayoutContent: React.FC = () => {
           },
           onDone: () => {
             flushStreamState(false);
-            if (abortControllersRef.current[requestChatId] === abortController) {
+            if (
+              abortControllersRef.current[requestChatId] === abortController
+            ) {
               abortControllersRef.current[requestChatId] = null;
             }
           },

--- a/src/app/_components/ChatPanel/ChatPanel.tsx
+++ b/src/app/_components/ChatPanel/ChatPanel.tsx
@@ -15,6 +15,9 @@ import {
   CircularProgress,
   Paper,
   Link,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from '@mui/material';
 import TextareaAutosize from '@mui/material/TextareaAutosize';
 import CloseIcon from '@mui/icons-material/Close';
@@ -25,6 +28,18 @@ import CheckIcon from '@mui/icons-material/Check';
 import { format, isToday } from 'date-fns';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import Markdown from 'markdown-to-jsx';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import AutorenewIcon from '@mui/icons-material/Autorenew';
+
+const thinkingSpinnerSx = {
+  fontSize: 15,
+  color: '#d97706',
+  animation: 'tapis-thinking-spin 1s linear infinite',
+  '@keyframes tapis-thinking-spin': {
+    '0%': { transform: 'rotate(0deg)' },
+    '100%': { transform: 'rotate(360deg)' },
+  },
+} as const;
 
 /**
  * Styled inline code span for chat markdown rendering.
@@ -177,6 +192,7 @@ export type ChatMessage = {
   role: 'user' | 'assistant' | 'system';
   content: string;
   timestamp?: number | Date | string;
+  meta?: import('app/_context/chat/agentTypes').ChatMessageMeta;
 };
 
 export type ChatPanelProps = {
@@ -907,6 +923,9 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
     : parseWidth(width) ?? CLAMP_FALLBACK_WIDTH;
   const effectiveHeight = resizable ? panelHeight : height;
   const headerDraggableAreaHeight = 48;
+  const hasActiveStreamingMessage = messages.some(
+    (m) => m.role === 'assistant' && Boolean(m.meta?.stream?.streaming)
+  );
 
   return (
     <>
@@ -1395,6 +1414,77 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
                         {m.content}
                       </Markdown>
                     </Box>
+                    {m.role === 'assistant' &&
+                      m.meta?.stream?.streaming &&
+                      !m.content &&
+                      !m.meta?.stream?.thinking && (
+                        <Stack
+                          direction="row"
+                          spacing={0.75}
+                          alignItems="center"
+                          sx={{ mt: 0.5 }}
+                        >
+                          <AutorenewIcon sx={thinkingSpinnerSx} />
+                          <Typography variant="caption" color="text.secondary">
+                            Streaming response...
+                          </Typography>
+                        </Stack>
+                      )}
+                    {m.role === 'assistant' && m.meta?.stream?.thinking && (
+                      <Accordion
+                        disableGutters
+                        elevation={0}
+                        sx={{
+                          mt: 1,
+                          bgcolor: '#fff7e6',
+                          border: '1px solid #ffe2b7',
+                          borderRadius: 1,
+                          '&:before': { display: 'none' },
+                        }}
+                      >
+                        <AccordionSummary
+                          expandIcon={<ExpandMoreIcon fontSize="small" />}
+                          sx={{
+                            minHeight: 30,
+                            '& .MuiAccordionSummary-content': { my: 0.5 },
+                          }}
+                        >
+                          <Stack
+                            direction="row"
+                            spacing={0.75}
+                            alignItems="center"
+                          >
+                            {m.meta?.stream?.thinkingInProgress ? (
+                              <AutorenewIcon sx={thinkingSpinnerSx} />
+                            ) : null}
+                            <Typography
+                              variant="caption"
+                              sx={{ fontWeight: 600, color: '#8a5800' }}
+                            >
+                              {m.meta?.stream?.thinkingInProgress
+                                ? 'Thinking (streaming...)'
+                                : 'Thinking trace'}
+                            </Typography>
+                          </Stack>
+                        </AccordionSummary>
+                        <AccordionDetails sx={{ pt: 0, pb: 1 }}>
+                          <Typography
+                            variant="caption"
+                            component="pre"
+                            sx={{
+                              m: 0,
+                              whiteSpace: 'pre-wrap',
+                              fontFamily:
+                                '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+                              fontSize: '0.72rem',
+                              color: '#7a5a22',
+                            }}
+                          >
+                            {m.meta.stream.thinking}
+                          </Typography>
+                        </AccordionDetails>
+                      </Accordion>
+                    )}
                     <Tooltip
                       title={
                         copiedMessageId === m.id ? 'Copied!' : 'Copy message'
@@ -1430,7 +1520,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
                   </Box>
                 </Box>
               ))}
-          {isSending && (
+          {isSending && !hasActiveStreamingMessage && (
             <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
               <Box
                 sx={{

--- a/src/app/_context/chat/ChatConfig.ts
+++ b/src/app/_context/chat/ChatConfig.ts
@@ -1,11 +1,12 @@
 import { ReactNode } from 'react';
-import { Agent, AgentContext } from './agentTypes';
+import { Agent, AgentContext, type ChatMessageMeta } from './agentTypes';
 
 export type ChatMessage = {
   id: string;
   role: 'user' | 'assistant' | 'system';
   content: string;
   timestamp?: number;
+  meta?: ChatMessageMeta;
 };
 
 export type ChatConfig = {

--- a/src/app/_context/chat/agentTypes.ts
+++ b/src/app/_context/chat/agentTypes.ts
@@ -1,8 +1,22 @@
+export type ChatMessageMeta = {
+  stream?: {
+    thinking: string;
+    thinkingInProgress: boolean;
+    streaming: boolean;
+  };
+};
+
 export type ChatTurn = {
   id: string;
   role: 'user' | 'assistant' | 'system';
   content: string;
-  meta?: any;
+  meta?: ChatMessageMeta;
+};
+
+export type AgentStreamHandlers = {
+  onDelta?: (delta: string) => void;
+  onDone?: () => void;
+  signal?: AbortSignal;
 };
 
 export type AgentContext = {
@@ -31,4 +45,9 @@ export interface Agent {
   name: string;
   description?: string;
   respond: (history: ChatTurn[], context: AgentContext) => Promise<AgentResult>;
+  respondStream?: (
+    history: ChatTurn[],
+    context: AgentContext,
+    handlers: AgentStreamHandlers
+  ) => Promise<AgentResult>;
 }


### PR DESCRIPTION
## Summary
- Adds optional `respondStream` to the agent contract; wires the model selection agent to LiteLLM's streaming endpoint, emitting `<think>...</think>`-wrapped reasoning deltas separately from visible content
- ChatPanel renders an inline streaming placeholder and a collapsible thinking-trace accordion while a message is mid-stream
- Refactors Layout chat state to be keyed per chat assistant, so switching between chats preserves each session's history and in-flight streams; adds per-chat abort controllers and persistence that skips localStorage writes during active streams