### PR TITLE
I-frame smart labeler

### DIFF
--- a/packages/icicle-tapisui-extension/src/index.ts
+++ b/packages/icicle-tapisui-extension/src/index.ts
@@ -27,6 +27,7 @@ import {
   FoodLogisticsAaaS,
   Patra,
 } from './pages';
+import { SmartLabeler } from './pages/SmartLabeler';
 
 const extension = createExtension({
   allowMultiTenant: false,
@@ -68,6 +69,7 @@ const extension = createExtension({
     'apps',
     'harvest',
     'patra',
+    'smart-labeler',
     //'data-labeler',
     //'smart-scheduler',
   ],
@@ -103,6 +105,7 @@ const extension = createExtension({
         'apps',
         'harvest',
         'patra',
+        'smart-labeler',
       ],
     },
   },
@@ -258,6 +261,14 @@ extension.registerService({
   iconName: 'globe',
   component: DigitalAgOpenPASS,
 });
+
+extension.registerService({
+  id: 'smart-labeler',
+  sidebarDisplayName: 'Smart Labeling and Annotation',
+  iconName: 'globe',
+  component: SmartLabeler,
+});
+
 extension.registerService({
   id: 'harvest',
   sidebarDisplayName: 'Harvest',

--- a/packages/icicle-tapisui-extension/src/pages/SmartLabeler/SmartLabeler.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/SmartLabeler/SmartLabeler.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { SectionHeader } from '@tapis/tapisui-common';
+import { Component } from '@tapis/tapisui-extensions-core';
+export const SmartLabeler: Component = ({ accessToken }) => {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {accessToken ? (
+        <iframe
+          style={{ flexGrow: 1, border: 'none' }}
+          src={`https://smart-labeler-sailab.nrp-nautilus.io/`}
+        />
+      ) : (
+        <>Invalid JWT. Log out of TapisUI then log back in</>
+      )}
+    </div>
+  );
+};
+export default SmartLabeler;

--- a/packages/icicle-tapisui-extension/src/pages/SmartLabeler/index.ts
+++ b/packages/icicle-tapisui-extension/src/pages/SmartLabeler/index.ts
@@ -1,0 +1,1 @@
+export { default as SmartLabeler } from './SmartLabeler';


### PR DESCRIPTION
## Overview:

Code to I-Frame the new Smart Labeler component

## Summary of Changes:

- Smart Labeler service registration.
- Component to I-frame smart_labeler service

## Testing Steps:

1.  New Tool called "Smart Labeling and Annotation" will be visible in Tapis tool bar at the left. 

## UI Photos:

<img width="1364" height="827" alt="Screenshot 2026-05-08 at 9 57 21 PM" src="https://github.com/user-attachments/assets/f4125b44-d327-4712-b0f1-3838b1e2e746" />

## Notes:
For now the smart-labeler service has been deployed through NRP kubernetes pods, will shift to Tapis pods if required.
