### PR TITLE
Smart Labeler - URL change for smart labeler I-frame

### DIFF
--- a/packages/icicle-tapisui-extension/src/pages/SmartLabeler/SmartLabeler.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/SmartLabeler/SmartLabeler.tsx
@@ -15,7 +15,7 @@ export const SmartLabeler: Component = ({ accessToken }) => {
       {accessToken ? (
         <iframe
           style={{ flexGrow: 1, border: 'none' }}
-          src={`https://smart-labeler-sailab.nrp-nautilus.io/`}
+          src={`https://smartlabeler.pods.icicleai.tapis.io/`}
         />
       ) : (
         <>Invalid JWT. Log out of TapisUI then log back in</>


### PR DESCRIPTION
## Overview:

Smart Labeler - URL change for smart labeler I-frame

## Summary of Changes:

The smart labeler service has been deployed through Tapis pods now instead of NRP. We the access URL is modified in the I-Frame
