### PR TITLE
Fix Portal service-list scrolling, drop "(beta)" from Portal Home and ICICLE Chatbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ web_modules/
 .env.test
 agents.md
 AGENTS.md
+CLAUDE.md
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/packages/icicle-tapisui-extension/src/index.ts
+++ b/packages/icicle-tapisui-extension/src/index.ts
@@ -20,6 +20,7 @@ import {
   FoodSecuritySandbox,
   PortalHome,
   DomainAgnosticAI,
+  ICICLEChatbook,
   DomainAgnosticCI,
   DomainSpecificServices,
   DigitalAgAaaS,
@@ -52,6 +53,7 @@ const extension = createExtension({
     'training-catalog',
     'home',
     'domain-agnostic-ai',
+    'icicle-chatbook',
     'domain-agnostic-ci',
     'domain-specific-services',
     'digital-ag-aaas',
@@ -88,6 +90,7 @@ const extension = createExtension({
         'analytics',
         'training-catalog',
         'domain-agnostic-ai',
+        'icicle-chatbook',
         'domain-agnostic-ci',
         'domain-specific-services',
         'digital-ag-aaas',
@@ -131,7 +134,7 @@ const extension = createExtension({
 // Order of registration determines sidebar order!!
 extension.registerService({
   id: 'home',
-  sidebarDisplayName: 'Portal Home (beta)',
+  sidebarDisplayName: 'Portal Home',
   iconName: 'globe',
   component: PortalHome,
 });
@@ -141,6 +144,13 @@ extension.registerService({
   sidebarDisplayName: 'ICICLE-AIaaS',
   iconName: 'globe',
   component: DomainAgnosticAI,
+});
+
+extension.registerService({
+  id: 'icicle-chatbook',
+  sidebarDisplayName: 'ICICLE Chatbook',
+  iconName: 'globe',
+  component: ICICLEChatbook,
 });
 
 extension.registerService({

--- a/packages/icicle-tapisui-extension/src/pages/DomainAgnosticAI/DomainAgnosticAI.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/DomainAgnosticAI/DomainAgnosticAI.tsx
@@ -25,6 +25,13 @@ const services: ServiceItem[] = [
     internal: true,
   },
   {
+    label:
+      'ICICLE Chatbook: A Chatbook built on top of ICICLE CI services to let you chat with your text, PDF, and other data.',
+    name: 'ICICLE Chatbook',
+    link: '/icicle-chatbook',
+    internal: true,
+  },
+  {
     label: 'Semi Supervised and Fully Supervised High-Performance Training',
     name: 'Upcoming',
     link: '#',

--- a/packages/icicle-tapisui-extension/src/pages/ICICLEChatbook/ICICLEChatbook.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/ICICLEChatbook/ICICLEChatbook.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Component } from '@tapis/tapisui-extensions-core';
+
+export const ICICLEChatbook: Component = ({ accessToken }) => {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {accessToken ? (
+        <iframe
+          style={{ flexGrow: 1, border: 'none' }}
+          src="https://iciclechatbook.pods.icicleai.tapis.io/"
+          title="ICICLE Chatbook"
+        />
+      ) : (
+        <>Invalid JWT. Log out of TapisUI then log back in</>
+      )}
+    </div>
+  );
+};
+
+export default ICICLEChatbook;

--- a/packages/icicle-tapisui-extension/src/pages/ICICLEChatbook/index.ts
+++ b/packages/icicle-tapisui-extension/src/pages/ICICLEChatbook/index.ts
@@ -1,0 +1,1 @@
+export { default as ICICLEChatbook } from './ICICLEChatbook';

--- a/packages/icicle-tapisui-extension/src/pages/PortalShared/PortalPageLayout.module.scss
+++ b/packages/icicle-tapisui-extension/src/pages/PortalShared/PortalPageLayout.module.scss
@@ -1,7 +1,8 @@
 .page {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  height: 100%;
+  overflow-y: auto;
   background: #ffffff;
 }
 
@@ -34,7 +35,7 @@
   margin: 0 auto;
   padding: 2rem;
   width: 100%;
-  min-height: 100%;
+  flex: 1 1 auto;
   background: #ffffff;
   box-sizing: border-box;
   padding-bottom: 3rem;

--- a/packages/icicle-tapisui-extension/src/pages/index.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/index.tsx
@@ -15,6 +15,7 @@ export { FEAST } from './FEAST';
 export { FoodSecuritySandbox } from './FoodSecuritySandbox';
 export { PortalHome } from './PortalHome';
 export { DomainAgnosticAI } from './DomainAgnosticAI';
+export { ICICLEChatbook } from './ICICLEChatbook';
 export { DomainAgnosticCI } from './DomainAgnosticCI';
 export { DomainSpecificServices } from './DomainSpecificServices';
 export { DigitalAgAaaS } from './DigitalAgAaaS';

--- a/src/app/_components/Sidebar/Sidebar.tsx
+++ b/src/app/_components/Sidebar/Sidebar.tsx
@@ -380,7 +380,7 @@ const Sidebar: React.FC = () => {
       <Navbar>
         {isIcicleExtension &&
           accessToken &&
-          renderSidebarItem('/home', 'globe', 'Portal Home(beta)')}
+          renderSidebarItem('/home', 'globe', 'Portal Home')}
         {renderSidebarItem(
           extensionName === '@icicle/tapisui-extension' ? '/dashboard' : '/',
           'dashboard',


### PR DESCRIPTION
## Overview:

Adds the ICICLE Chatbook service to the ICICLE portal and fixes two issues on the Portal pages: the service lists not scrolling, and the "(beta)" tag on Portal Home.

## Related Github Issues:

- [TUI-526](https://github.com/tapis-project/tapis-ui/issues/526)

## Summary of Changes:
- New "ICICLE Chatbook" left-sidebar item: an embedded iframe page (https://iciclechatbook.pods.icicleai.tapis.io/).
- Added ICICLE Chatbook to the ICICLE-AIaaS (Domain Agnostic AI) service list.
- Fixed Portal service lists not scrolling. 
- Removed "(beta)" from the Portal Home label (sidebar item and extension display name).

## Testing Steps:

1. Run on an ICICLE base URL then`pnpm -r build && pnpm start`.
2. Log in; confirm the sidebar reads "Portal Home" (no "(beta)").
3. Open ICICLE-AIaaS and confirm the long service list scrolls fully.
4. Confirm "ICICLE Chatbook" appears in the left sidebar and in the AIaaS list; click it and confirm the Chatbook iframe loads.

## UI Photos:
<img width="1887" height="995" alt="img1" src="https://github.com/user-attachments/assets/04dba7e8-f8b8-4fc8-8a50-896444652743" />
<img width="1887" height="995" alt="img2" src="https://github.com/user-attachments/assets/6638e729-862e-43c7-95db-70239f49c48a" />