### PR TITLE
Remove beta banner from Model Discovery UI

### DIFF
--- a/src/app/MlHub/Models/NativeModelSearch/NativeModelsSearch.tsx
+++ b/src/app/MlHub/Models/NativeModelSearch/NativeModelsSearch.tsx
@@ -243,73 +243,73 @@ const NativeModelsSearch: React.FC = () => {
             state.prevCursor === undefined && state.currentCursor === undefined
               ? undefined
               : () => {
-                let libraries = filters.libraries.filter(
-                  (l) => l !== null && l !== undefined
-                );
+                  let libraries = filters.libraries.filter(
+                    (l) => l !== null && l !== undefined
+                  );
 
-                let taskTypes = filters.task_types.filter(
-                  (t) => t !== null && t !== undefined
-                );
+                  let taskTypes = filters.task_types.filter(
+                    (t) => t !== null && t !== undefined
+                  );
 
-                let criterion: Models.DiscoveryCriterion = {};
-                if (libraries.length > 0) {
-                  criterion['libraries'] = libraries;
-                }
-
-                if (taskTypes.length > 0) {
-                  criterion['task_types'] = taskTypes;
-                }
-                discover(
-                  {
-                    limit: filters.limit,
-                    includeCount: true,
-                    cursor: state.prevCursor,
-                    discoveryCriteria: {
-                      criteria: [criterion],
-                    },
-                  },
-                  {
-                    onSuccess: onSuccessPrevious,
+                  let criterion: Models.DiscoveryCriterion = {};
+                  if (libraries.length > 0) {
+                    criterion['libraries'] = libraries;
                   }
-                );
-              }
+
+                  if (taskTypes.length > 0) {
+                    criterion['task_types'] = taskTypes;
+                  }
+                  discover(
+                    {
+                      limit: filters.limit,
+                      includeCount: true,
+                      cursor: state.prevCursor,
+                      discoveryCriteria: {
+                        criteria: [criterion],
+                      },
+                    },
+                    {
+                      onSuccess: onSuccessPrevious,
+                    }
+                  );
+                }
           }
           next={
             state.cursors.length < 0 || state.nextCursor === undefined
               ? undefined
               : () => {
-                let libraries = filters.libraries.filter(
-                  (l) => l !== null && l !== undefined
-                );
+                  let libraries = filters.libraries.filter(
+                    (l) => l !== null && l !== undefined
+                  );
 
-                let taskTypes = filters.task_types.filter(
-                  (t) => t !== null && t !== undefined
-                );
+                  let taskTypes = filters.task_types.filter(
+                    (t) => t !== null && t !== undefined
+                  );
 
-                let criterion: Models.DiscoveryCriterion = {};
+                  let criterion: Models.DiscoveryCriterion = {};
 
-                if (libraries.length > 0) {
-                  criterion['libraries'] = libraries;
-                }
-
-                if (taskTypes.length > 0) {
-                  criterion['task_types'] = taskTypes;
-                }
-
-                discover(
-                  {
-                    limit: filters.limit,
-                    includeCount: true,
-                    cursor: state.cursors.at(-1),
-                    discoveryCriteria: {
-                      criteria: [criterion],
-                    },
-                  },
-                  {
-                    onSuccess: onSuccessNext,
+                  if (libraries.length > 0) {
+                    criterion['libraries'] = libraries;
                   }
-                );
-              }
+
+                  if (taskTypes.length > 0) {
+                    criterion['task_types'] = taskTypes;
+                  }
+
+                  discover(
+                    {
+                      limit: filters.limit,
+                      includeCount: true,
+                      cursor: state.cursors.at(-1),
+                      discoveryCriteria: {
+                        criteria: [criterion],
+                      },
+                    },
+                    {
+                      onSuccess: onSuccessNext,
+                    }
+                  );
+                }
           }
           isLoading={isLoading}
         />

--- a/src/app/MlHub/Models/NativeModelSearch/NativeModelsSearch.tsx
+++ b/src/app/MlHub/Models/NativeModelSearch/NativeModelsSearch.tsx
@@ -138,11 +138,6 @@ const NativeModelsSearch: React.FC = () => {
 
   return (
     <div className={styles['native-models-search-container']}>
-      <Alert severity="warning">
-        <AlertTitle>Model Discovery Beta</AlertTitle>
-        Model discovery funtionality is available, however the deployment
-        strategies listed in some table entries is purely for demonstration
-      </Alert>
       <div>
         <SectionHeader>
           Discover Models
@@ -248,73 +243,73 @@ const NativeModelsSearch: React.FC = () => {
             state.prevCursor === undefined && state.currentCursor === undefined
               ? undefined
               : () => {
-                  let libraries = filters.libraries.filter(
-                    (l) => l !== null && l !== undefined
-                  );
+                let libraries = filters.libraries.filter(
+                  (l) => l !== null && l !== undefined
+                );
 
-                  let taskTypes = filters.task_types.filter(
-                    (t) => t !== null && t !== undefined
-                  );
+                let taskTypes = filters.task_types.filter(
+                  (t) => t !== null && t !== undefined
+                );
 
-                  let criterion: Models.DiscoveryCriterion = {};
-                  if (libraries.length > 0) {
-                    criterion['libraries'] = libraries;
-                  }
-
-                  if (taskTypes.length > 0) {
-                    criterion['task_types'] = taskTypes;
-                  }
-                  discover(
-                    {
-                      limit: filters.limit,
-                      includeCount: true,
-                      cursor: state.prevCursor,
-                      discoveryCriteria: {
-                        criteria: [criterion],
-                      },
-                    },
-                    {
-                      onSuccess: onSuccessPrevious,
-                    }
-                  );
+                let criterion: Models.DiscoveryCriterion = {};
+                if (libraries.length > 0) {
+                  criterion['libraries'] = libraries;
                 }
+
+                if (taskTypes.length > 0) {
+                  criterion['task_types'] = taskTypes;
+                }
+                discover(
+                  {
+                    limit: filters.limit,
+                    includeCount: true,
+                    cursor: state.prevCursor,
+                    discoveryCriteria: {
+                      criteria: [criterion],
+                    },
+                  },
+                  {
+                    onSuccess: onSuccessPrevious,
+                  }
+                );
+              }
           }
           next={
             state.cursors.length < 0 || state.nextCursor === undefined
               ? undefined
               : () => {
-                  let libraries = filters.libraries.filter(
-                    (l) => l !== null && l !== undefined
-                  );
+                let libraries = filters.libraries.filter(
+                  (l) => l !== null && l !== undefined
+                );
 
-                  let taskTypes = filters.task_types.filter(
-                    (t) => t !== null && t !== undefined
-                  );
+                let taskTypes = filters.task_types.filter(
+                  (t) => t !== null && t !== undefined
+                );
 
-                  let criterion: Models.DiscoveryCriterion = {};
+                let criterion: Models.DiscoveryCriterion = {};
 
-                  if (libraries.length > 0) {
-                    criterion['libraries'] = libraries;
-                  }
-
-                  if (taskTypes.length > 0) {
-                    criterion['task_types'] = taskTypes;
-                  }
-
-                  discover(
-                    {
-                      limit: filters.limit,
-                      includeCount: true,
-                      cursor: state.cursors.at(-1),
-                      discoveryCriteria: {
-                        criteria: [criterion],
-                      },
-                    },
-                    {
-                      onSuccess: onSuccessNext,
-                    }
-                  );
+                if (libraries.length > 0) {
+                  criterion['libraries'] = libraries;
                 }
+
+                if (taskTypes.length > 0) {
+                  criterion['task_types'] = taskTypes;
+                }
+
+                discover(
+                  {
+                    limit: filters.limit,
+                    includeCount: true,
+                    cursor: state.cursors.at(-1),
+                    discoveryCriteria: {
+                      criteria: [criterion],
+                    },
+                  },
+                  {
+                    onSuccess: onSuccessNext,
+                  }
+                );
+              }
           }
           isLoading={isLoading}
         />


### PR DESCRIPTION
## Overview:

Removes the beta warning banner from the top of the Model Discovery UI now that the banner is no longer needed.

## Related Github Issues:

- [#533](https://github.com/tapis-project/tapis-ui/issues/533)

## Summary of Changes:

- Removed the "Model Discovery Beta" warning alert from the Native Model Discovery page.

## Testing Steps:

1. Open the Model Discovery UI.
2. Confirm the beta banner no longer appears at the top of the page.
3. Confirm the rest of the model discovery controls still render normally.


## UI Photos:
<img width="1920" height="1082" alt="image" src="https://github.com/user-attachments/assets/04b0b8f6-8088-4e89-a6ce-a591156bf93d" />


