### PR TITLE
fix(icicle): hand off portal auth to Patra

### DIFF
--- a/packages/icicle-tapisui-extension/src/pages/Patra/Patra.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/Patra/Patra.tsx
@@ -1,6 +1,68 @@
 import * as React from 'react';
+import { Component } from '@tapis/tapisui-extensions-core';
 
-export const Patra: React.FC = () => {
+const PATRA_ORIGIN = 'https://patra.pods.icicleai.tapis.io';
+const AUTH_REQUEST_TYPE = 'patra:portal-auth:request';
+const AUTH_RESPONSE_TYPE = 'patra:portal-auth:response';
+const AUTH_PROTOCOL_VERSION = 1;
+
+type PortalAuthRequest = {
+  type: typeof AUTH_REQUEST_TYPE;
+  version: typeof AUTH_PROTOCOL_VERSION;
+  requestId: string;
+};
+
+const isPortalAuthRequest = (value: unknown): value is PortalAuthRequest => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const request = value as Partial<PortalAuthRequest>;
+  return (
+    request.type === AUTH_REQUEST_TYPE &&
+    request.version === AUTH_PROTOCOL_VERSION &&
+    typeof request.requestId === 'string' &&
+    request.requestId.length >= 16 &&
+    request.requestId.length <= 256
+  );
+};
+
+export const Patra: Component = ({ accessToken }) => {
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+
+  React.useEffect(() => {
+    if (!accessToken) {
+      return;
+    }
+
+    const handlePortalAuthRequest = (event: MessageEvent) => {
+      const patraWindow = iframeRef.current?.contentWindow;
+      if (
+        event.origin !== PATRA_ORIGIN ||
+        !patraWindow ||
+        event.source !== patraWindow ||
+        !isPortalAuthRequest(event.data)
+      ) {
+        return;
+      }
+
+      const response = {
+        type: AUTH_RESPONSE_TYPE,
+        version: AUTH_PROTOCOL_VERSION,
+        requestId: event.data.requestId,
+        accessToken,
+        tokenType: 'Bearer',
+      };
+
+      (event.source as Window).postMessage(response, event.origin);
+    };
+
+    window.addEventListener('message', handlePortalAuthRequest);
+    return () => {
+      window.removeEventListener('message', handlePortalAuthRequest);
+    };
+  }, [accessToken]);
+
   return (
     <div
       style={{
@@ -11,10 +73,16 @@ export const Patra: React.FC = () => {
         overflow: 'hidden',
       }}
     >
-      <iframe
-        style={{ flexGrow: 1, border: 'none' }}
-        src="https://patra.pods.icicleai.tapis.io"
-      />
+      {accessToken ? (
+        <iframe
+          ref={iframeRef}
+          style={{ flexGrow: 1, border: 'none' }}
+          src={PATRA_ORIGIN}
+          title="Patra"
+        />
+      ) : (
+        <>Invalid JWT. Log out of TapisUI then log back in</>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- keep the existing ICICLE sidebar and Patra iframe UI unchanged
- respond to Patra embedded-auth protocol v1 requests using the current TapisUI access token
- require the exact Patra origin and exact iframe contentWindow
- echo the single-use requestId and reply with event.source.postMessage(response, event.origin)
- never put the token in the iframe URL, storage, or logs

## Verification

- built the ICICLE extension and its workspace dependency closure successfully with pnpm in Linux
- Patra frontend separately validates source, origin, protocol version, requestId, JWT shape, and expiry

This is intentionally limited to packages/icicle-tapisui-extension/src/pages/Patra/Patra.tsx and does not modify the outer portal sidebar.