### PR TITLE
 Decouple ICICLE landing-page logic from base src via serviceMap lookup

### DIFF
--- a/src/app/Dashboard/_components/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/_components/Dashboard/Dashboard.tsx
@@ -71,8 +71,7 @@ const Dashboard: React.FC = () => {
   const navigate = useHistory();
   // TODO All tenant-specific functionality must be refactored into their respective
   // extenstions
-  const { extension, extensionName } = useExtension();
-  const isIcicle = extensionName === '@icicle/tapisui-extension';
+  const { extension } = useExtension();
 
   // Hidden dev token input — revealed by long-pressing "TAPIS" for 3s
   const isDevHost =

--- a/src/app/Login/_Layout/Layout.tsx
+++ b/src/app/Login/_Layout/Layout.tsx
@@ -8,15 +8,12 @@ import { useExtension } from 'extensions';
 
 const Layout: React.FC = () => {
   const { accessToken, basePath } = useTapisConfig();
-  const { extensionName } = useExtension();
+  const { extension } = useExtension();
   let location = useLocation<{ from: Location }>();
   let { from } = location.state || { from: { pathname: '/' } };
+  const landingRoute = extension?.serviceMap?.['home']?.route;
   if (accessToken?.access_token) {
-    return (
-      <Redirect
-        to={extensionName === '@icicle/tapisui-extension' ? '/home' : from}
-      />
-    );
+    return <Redirect to={landingRoute ?? from} />;
   }
 
   const body = (

--- a/src/app/_Router/Router.tsx
+++ b/src/app/_Router/Router.tsx
@@ -25,16 +25,13 @@ import { useExtension } from 'extensions';
 const Router: React.FC = () => {
   const { accessToken } = useTapisConfig();
   const { logout } = Auth.useLogin();
-  const { extension, extensionName } = useExtension();
+  const { extension } = useExtension();
+  const landingRoute = extension?.serviceMap?.['home']?.route;
 
   return (
     <Switch>
       <Route exact path="/">
-        {extensionName === '@icicle/tapisui-extension' ? (
-          <Redirect to="/home" />
-        ) : (
-          <Dashboard />
-        )}
+        {landingRoute ? <Redirect to={landingRoute} /> : <Dashboard />}
       </Route>
       <Route exact path="/dashboard">
         <Dashboard />

--- a/src/app/_components/Sidebar/Sidebar.tsx
+++ b/src/app/_components/Sidebar/Sidebar.tsx
@@ -68,14 +68,17 @@ type SidebarItems = {
 const Sidebar: React.FC = () => {
   const { accessToken, claims, domainsMatched, basePath } = useTapisConfig();
   const isAuthenticated = Boolean(accessToken?.access_token);
-  const { extension, extensionName } = useExtension();
+  const { extension } = useExtension();
   const chatContextValue = useContext(ChatContext);
   const queryClient = useQueryClient();
   const podsAdminMode = useSyncExternalStore(
     subscribePodsAdminMode,
     getPodsAdminMode
   );
-  const isIcicleExtension = extensionName === '@icicle/tapisui-extension';
+  const landingServiceId =
+    extension?.serviceMap && 'home' in extension.serviceMap
+      ? 'home'
+      : undefined;
   const [expanded, setExpanded] = useState(true);
   const [openSecondary, setOpenSecondary] = useState(false); //Added openSecondary state to manage the visibility of the secondary sidebar items.
   const [modal, setModal] = useState<string | undefined>(undefined);
@@ -378,11 +381,9 @@ const Sidebar: React.FC = () => {
       />
 
       <Navbar>
-        {isIcicleExtension &&
-          accessToken &&
-          renderSidebarItem('/home', 'globe', 'Portal Home')}
+        {landingServiceId && accessToken && sidebarItems[landingServiceId]}
         {renderSidebarItem(
-          extensionName === '@icicle/tapisui-extension' ? '/dashboard' : '/',
+          landingServiceId ? '/dashboard' : '/',
           'dashboard',
           'Dashboard'
         )}
@@ -395,8 +396,7 @@ const Sidebar: React.FC = () => {
                 {/* No Section items - always visible */}
                 {extension.betaSidebar.noSection?.mainServices
                   ?.filter(
-                    (serviceId: string) =>
-                      !(isIcicleExtension && serviceId === 'home')
+                    (serviceId: string) => serviceId !== landingServiceId
                   )
                   .map((serviceId: string) => sidebarItems[serviceId])}
                 {extension.betaSidebar.noSection?.secondaryServices &&
@@ -432,7 +432,7 @@ const Sidebar: React.FC = () => {
                         {extension.betaSidebar.noSection.secondaryServices
                           .filter(
                             (serviceId: string) =>
-                              !(isIcicleExtension && serviceId === 'home')
+                              serviceId !== landingServiceId
                           )
                           .map((serviceId: string) => sidebarItems[serviceId])}
                       </Collapse>
@@ -482,8 +482,7 @@ const Sidebar: React.FC = () => {
                       {/* Main services in section */}
                       {section.mainServices
                         .filter(
-                          (serviceId: string) =>
-                            !(isIcicleExtension && serviceId === 'home')
+                          (serviceId: string) => serviceId !== landingServiceId
                         )
                         .map((serviceId: string) => sidebarItems[serviceId])}
 
@@ -528,7 +527,7 @@ const Sidebar: React.FC = () => {
                               {section.secondaryServices
                                 .filter(
                                   (serviceId: string) =>
-                                    !(isIcicleExtension && serviceId === 'home')
+                                    serviceId !== landingServiceId
                                 )
                                 .map(
                                   (serviceId: string) => sidebarItems[serviceId]


### PR DESCRIPTION
## Overview:
Drive the `/` and post-login landing redirect and the pinned sidebar "Portal Home" item from the registered `home` service in the extension's serviceMap, instead of hardcoded `extensionName === '@icicle/...'` checks in Router, Login layout, and Sidebar. Also, drop the unused `isIcicle` variable from Dashboard.

Behavior is unchanged (ICICLE lands on /home; base TapisUI lands on the Dashboard), and no extension-core models were modified.
