### PR TITLE
Sort portal service lists by availability then name via shared sortSe…

### DIFF
--- a/packages/icicle-tapisui-extension/src/pages/AnimalEcologyAaaS/AnimalEcologyAaaS.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/AnimalEcologyAaaS/AnimalEcologyAaaS.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Component } from '@tapis/tapisui-extensions-core';
 import PortalPageLayout from '../PortalShared/PortalPageLayout';
+import { sortServices } from '../PortalShared/sortServices';
 import styles from '../PortalShared/PortalPageLayout.module.scss';
 
 type ServiceItem = {
@@ -24,6 +25,8 @@ const services: ServiceItem[] = [
   },
 ];
 
+const sortedServices = sortServices(services);
+
 export const AnimalEcologyAaaS: Component = () => {
   return (
     <PortalPageLayout title="Welcome to the ICICLE-Animal-Ecology-as-a-Service (ICICLE-AEaaS) page!">
@@ -38,7 +41,7 @@ export const AnimalEcologyAaaS: Component = () => {
             </p>
           </div>
           <div className={styles.serviceList}>
-            {services.map((service) => (
+            {sortedServices.map((service) => (
               <div key={service.label} className={styles.serviceRow}>
                 <div className={styles.serviceLabel}>{service.label}</div>
                 <div className={styles.cardText}>Upcoming</div>

--- a/packages/icicle-tapisui-extension/src/pages/DigitalAgAaaS/DigitalAgAaaS.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/DigitalAgAaaS/DigitalAgAaaS.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Component } from '@tapis/tapisui-extensions-core';
 import PortalPageLayout from '../PortalShared/PortalPageLayout';
+import { sortServices } from '../PortalShared/sortServices';
 import styles from '../PortalShared/PortalPageLayout.module.scss';
 
 type ServiceItem = {
@@ -57,6 +58,8 @@ const services: ServiceItem[] = [
   },
 ];
 
+const sortedServices = sortServices(services);
+
 export const DigitalAgAaaS: Component = () => {
   return (
     <PortalPageLayout title="Welcome to the ICICLE-Digital-Agriculture-as-a-Service (ICICLE-DAaaS) page!">
@@ -71,7 +74,7 @@ export const DigitalAgAaaS: Component = () => {
             </p>
           </div>
           <div className={styles.serviceList}>
-            {services.map((service) => (
+            {sortedServices.map((service) => (
               <div key={service.label} className={styles.serviceRow}>
                 <div className={styles.serviceLabel}>{service.label}</div>
                 {service.upcoming ? (

--- a/packages/icicle-tapisui-extension/src/pages/DomainAgnosticAI/DomainAgnosticAI.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/DomainAgnosticAI/DomainAgnosticAI.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Component } from '@tapis/tapisui-extensions-core';
 import PortalPageLayout from '../PortalShared/PortalPageLayout';
+import { sortServices } from '../PortalShared/sortServices';
 import styles from '../PortalShared/PortalPageLayout.module.scss';
 
 type ServiceItem = {
@@ -90,6 +91,8 @@ const services: ServiceItem[] = [
   },
 ];
 
+const sortedServices = sortServices(services);
+
 export const DomainAgnosticAI: Component = () => {
   return (
     <PortalPageLayout title="Welcome to the ICICLE-AI-as-a-Service (ICICLE-AIaaS) page!">
@@ -103,7 +106,7 @@ export const DomainAgnosticAI: Component = () => {
             </p>
           </div>
           <div className={styles.serviceList}>
-            {services.map((service) => (
+            {sortedServices.map((service) => (
               <div key={service.name} className={styles.serviceRow}>
                 <div className={styles.serviceLabel}>{service.label}</div>
                 {service.upcoming ? (

--- a/packages/icicle-tapisui-extension/src/pages/DomainAgnosticCI/DomainAgnosticCI.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/DomainAgnosticCI/DomainAgnosticCI.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Component } from '@tapis/tapisui-extensions-core';
 import PortalPageLayout from '../PortalShared/PortalPageLayout';
+import { sortServices } from '../PortalShared/sortServices';
 import styles from '../PortalShared/PortalPageLayout.module.scss';
 
 type ServiceItem = {
@@ -66,6 +67,8 @@ const services: ServiceItem[] = [
   },
 ];
 
+const sortedServices = sortServices(services);
+
 export const DomainAgnosticCI: Component = () => {
   return (
     <PortalPageLayout title="Welcome to the ICICLE-CI-as-a-Service (ICICLE-CIaaS) page!">
@@ -83,7 +86,7 @@ export const DomainAgnosticCI: Component = () => {
             </p>
           </div>
           <div className={styles.serviceList}>
-            {services.map((service) => (
+            {sortedServices.map((service) => (
               <div key={service.name} className={styles.serviceRow}>
                 <div className={styles.serviceLabel}>{service.label}</div>
                 {service.upcoming ? (

--- a/packages/icicle-tapisui-extension/src/pages/FoodLogisticsAaaS/FoodLogisticsAaaS.tsx
+++ b/packages/icicle-tapisui-extension/src/pages/FoodLogisticsAaaS/FoodLogisticsAaaS.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Component } from '@tapis/tapisui-extensions-core';
 import PortalPageLayout from '../PortalShared/PortalPageLayout';
+import { sortServices } from '../PortalShared/sortServices';
 import styles from '../PortalShared/PortalPageLayout.module.scss';
 
 type ServiceItem = {
@@ -39,6 +40,8 @@ const services: ServiceItem[] = [
   },
 ];
 
+const sortedServices = sortServices(services);
+
 export const FoodLogisticsAaaS: Component = () => {
   return (
     <PortalPageLayout title="Welcome to the ICICLE-Food-Logistics-and-Security-as-a-Service (ICICLE-FLaaS) page!">
@@ -53,7 +56,7 @@ export const FoodLogisticsAaaS: Component = () => {
             </p>
           </div>
           <div className={styles.serviceList}>
-            {services.map((service) => (
+            {sortedServices.map((service) => (
               <div key={service.label} className={styles.serviceRow}>
                 <div className={styles.serviceLabel}>{service.label}</div>
                 {service.upcoming ? (

--- a/packages/icicle-tapisui-extension/src/pages/PortalShared/sortServices.ts
+++ b/packages/icicle-tapisui-extension/src/pages/PortalShared/sortServices.ts
@@ -1,0 +1,21 @@
+export type PortalServiceItem = {
+  label: string;
+  name?: string;
+  link?: string;
+  internal?: boolean;
+  upcoming?: boolean;
+};
+
+// A service is "available" when it has a real link (not a '#' placeholder)
+// and isn't flagged as upcoming.
+const isAvailable = (service: PortalServiceItem) =>
+  !service.upcoming && !!service.link && service.link !== '#';
+
+// Orders a service list for the portal landing pages: available (linked)
+// services first, alphabetically by label; then upcoming (no link) services,
+// alphabetically by label. Returns a new array; the input is left untouched.
+export const sortServices = <T extends PortalServiceItem>(services: T[]): T[] =>
+  [...services].sort((a, b) => {
+    if (isAvailable(a) !== isAvailable(b)) return isAvailable(a) ? -1 : 1;
+    return a.label.localeCompare(b.label);
+  });


### PR DESCRIPTION
…rvices helper

## Overview:

Order portal service lists: available (linked) first, then upcoming, each alphabetical

## Summary of Changes:

Ordered the service lists on the ICICLE portal landing pages so available (linked) services appear first, alphabetically, followed by "upcoming" (unlinked) services, also alphabetically.

New shared helper
- PortalShared/sortServices.ts — a single generic sortServices() utility (plus a PortalServiceItem type). It sorts available services (real link, not a # placeholder, not flagged upcoming) ahead of upcoming ones, each group ordered alphabetically by label. Returns a new array, leaving the source untouched.

Pages updated to use it (each now imports the helper and calls sortServices(services) instead of mapping the raw array):
  - DomainAgnosticAI.tsx (AIaaS) — mixed list, 7 available then 5 upcoming
  - DomainAgnosticCI.tsx (CIaaS) — mixed list, 5 available then 4 upcoming
  - DigitalAgAaaS.tsx (DOaaS → Digital Ag) — Harvest available, then 6 upcoming
  - FoodLogisticsAaaS.tsx (DOaaS → Food Logistics) — all available, alphabetized
  - AnimalEcologyAaaS.tsx (DOaaS → Animal Ecology) — all upcoming, alphabetized